### PR TITLE
resource/ovirt_disk: Use GiB as the unit of Disk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-Terraform oVirt Provider plugin[![Build Status](https://travis-ci.org/imjoey/terraform-provider-ovirt.svg?branch=master)](https://travis-ci.org/imjoey/terraform-provider-ovirt)
+Terraform oVirt Provider plugin
 ===============================
+
+[![Build Status](https://travis-ci.org/imjoey/terraform-provider-ovirt.svg?branch=master)](https://travis-ci.org/imjoey/terraform-provider-ovirt)
+[![Go Report Card](https://goreportcard.com/badge/github.com/imjoey/terraform-provider-ovirt)](https://goreportcard.com/report/github.com/imjoey/terraform-provider-ovirt)
+
+
 This plugin allows Terraform to work with the oVirt Virtual Machine management platform.
 It requires oVirt 4.x. 
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Use GiB to represent the Disk size
* Make acc test more intuitive and simple

Output from acceptance testing:

```
make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDisk_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtDisk_basic -timeout 180m
=== RUN   TestAccOvirtDisk_basic
--- PASS: TestAccOvirtDisk_basic (138.02s)
PASS
ok      github.com/imjoey/terraform-provider-ovirt/ovirt        138.049s
```