### PR TITLE
Set logic_name to Required instead of Optional.

### DIFF
--- a/ovirt/resource_ovirt_disk_attachment.go
+++ b/ovirt/resource_ovirt_disk_attachment.go
@@ -61,7 +61,7 @@ func resourceOvirtDiskAttachment() *schema.Resource {
 			},
 			"logical_name": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 			},
 			"pass_discard": &schema.Schema{
@@ -105,10 +105,9 @@ func resourceOvirtDiskAttachmentCreate(d *schema.ResourceData, meta interface{})
 		Bootable(d.Get("bootable").(bool)).
 		Active(d.Get("active").(bool)).
 		ReadOnly(d.Get("read_only").(bool)).
-		UsesScsiReservation(d.Get("use_scsi_reservation").(bool))
-	if logicalName, ok := d.GetOk("logical_name"); ok {
-		attachmentBuilder.LogicalName(logicalName.(string))
-	}
+		UsesScsiReservation(d.Get("use_scsi_reservation").(bool)).
+		LogicalName(d.Get("logical_name").(string))
+
 	if passDiscard, ok := d.GetOkExists("pass_discard"); ok {
 		attachmentBuilder.PassDiscard(passDiscard.(bool))
 	}
@@ -204,9 +203,8 @@ func resourceOvirtDiskAttachmentRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("interface", attachment.MustInterface())
 	d.Set("read_only", attachment.MustReadOnly())
 	d.Set("use_scsi_reservation", attachment.MustUsesScsiReservation())
-	if logicalName, ok := attachment.LogicalName(); ok {
-		d.Set("logical_name", logicalName)
-	}
+	d.Set("logical_name", attachment.MustLogicalName())
+
 	if passDiscard, ok := attachment.PassDiscard(); ok {
 		d.Set("pass_discard", passDiscard)
 	}

--- a/ovirt/resource_ovirt_disk_attachment_test.go
+++ b/ovirt/resource_ovirt_disk_attachment_test.go
@@ -107,6 +107,7 @@ resource "ovirt_disk_attachment" "attachment" {
 	bootable  = true
 	interface = "virtio"
 	active    = true
+	logical_name = "/dev/vda"
 	read_only = true
 }  
 `, vmID, diskID)
@@ -120,6 +121,7 @@ resource "ovirt_disk_attachment" "attachment" {
 	bootable  = false
 	interface = "virtio"
 	active    = false
+	logical_name = "/dev/vda"
 	read_only = true
 }  
 `, vmID, diskID)


### PR DESCRIPTION
Fixes #67 .

Changes proposed in this pull request:

* Set `logical_name` to be `Required`
* Minor changes of related codes

Output from acceptance testing:

```
make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDiskAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtDiskAttachment_basic -timeout 180m
=== RUN   TestAccOvirtDiskAttachment_basic
--- PASS: TestAccOvirtDiskAttachment_basic (12.82s)
PASS
ok      github.com/imjoey/terraform-provider-ovirt/ovirt        12.854s
```