### PR TITLE
r/ovirt_disk_attachment: Remove logical_name attribute

### DIFF
--- a/ovirt/resource_ovirt_disk_attachment.go
+++ b/ovirt/resource_ovirt_disk_attachment.go
@@ -59,11 +59,9 @@ func resourceOvirtDiskAttachment() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"logical_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+
+			// TODO: Add support for logical_name
+
 			"pass_discard": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -105,8 +103,7 @@ func resourceOvirtDiskAttachmentCreate(d *schema.ResourceData, meta interface{})
 		Bootable(d.Get("bootable").(bool)).
 		Active(d.Get("active").(bool)).
 		ReadOnly(d.Get("read_only").(bool)).
-		UsesScsiReservation(d.Get("use_scsi_reservation").(bool)).
-		LogicalName(d.Get("logical_name").(string))
+		UsesScsiReservation(d.Get("use_scsi_reservation").(bool))
 
 	if passDiscard, ok := d.GetOkExists("pass_discard"); ok {
 		attachmentBuilder.PassDiscard(passDiscard.(bool))
@@ -203,7 +200,6 @@ func resourceOvirtDiskAttachmentRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("interface", attachment.MustInterface())
 	d.Set("read_only", attachment.MustReadOnly())
 	d.Set("use_scsi_reservation", attachment.MustUsesScsiReservation())
-	d.Set("logical_name", attachment.MustLogicalName())
 
 	if passDiscard, ok := attachment.PassDiscard(); ok {
 		d.Set("pass_discard", passDiscard)

--- a/ovirt/resource_ovirt_disk_attachment_test.go
+++ b/ovirt/resource_ovirt_disk_attachment_test.go
@@ -17,8 +17,8 @@ import (
 
 func TestAccOvirtDiskAttachment_basic(t *testing.T) {
 	var diskAttachment ovirtsdk4.DiskAttachment
-	vmID := "d22d9233-8c9f-42f0-a137-ccd4af45dec7"
-	diskID := "8d54d1f5-4549-441f-8801-e2660c77a5c8"
+	vmID := "437d0f69-d1eb-441f-bf6b-0e97797fe11e"
+	diskID := "230349f6-59a9-47e9-bc90-7c1221645b07"
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		Providers:     testAccProviders,
@@ -107,7 +107,6 @@ resource "ovirt_disk_attachment" "attachment" {
 	bootable  = true
 	interface = "virtio"
 	active    = true
-	logical_name = "/dev/vda"
 	read_only = true
 }  
 `, vmID, diskID)
@@ -121,7 +120,6 @@ resource "ovirt_disk_attachment" "attachment" {
 	bootable  = false
 	interface = "virtio"
 	active    = false
-	logical_name = "/dev/vda"
 	read_only = true
 }  
 `, vmID, diskID)


### PR DESCRIPTION
Related with issue #67 

Changes proposed in this pull request:

* Remove the `logical_name` attribute

The `logical_name` attribute could not be retrieved via API before the guest agent installed in VM. So in this case, Terraform is not able to correctly manage the attribute, which definitely breaks the uniformity. Since `logical_name` could be gracefully managed by oVirt, just remove it now. A more ideal solution will be provided in future.

Output from acceptance testing:

```
OVIRT_USERNAME=admin@internal OVIRT_PASSWORD=qwer1234 OVIRT_URL=https://10.1.161.222/ovirt-engine/api make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDiskAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtDiskAttachment_basic -timeout 180m
=== RUN   TestAccOvirtDiskAttachment_basic
--- PASS: TestAccOvirtDiskAttachment_basic (3.17s)
PASS
ok      github.com/imjoey/terraform-provider-ovirt/ovirt        3.191s
```