### PR TITLE
Add headers param to oVirt connection

### DIFF
--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -38,6 +38,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("OVIRT_URL", os.Getenv("OVIRT_URL")),
 				Description: "Ovirt server url",
 			},
+			"headers": &schema.Schema{
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Default:     map[string]string{},
+				Description: "Additional headers to be added to each API call",
+			},
 		},
 		ConfigureFunc: ConfigureProvider,
 		ResourcesMap: map[string]*schema.Resource{
@@ -66,5 +72,6 @@ func ConfigureProvider(d *schema.ResourceData) (interface{}, error) {
 		Username(d.Get("username").(string)).
 		Password(d.Get("password").(string)).
 		Insecure(true).
+		Headers(d.Get("headers").(map[string]string)).
 		Build()
 }


### PR DESCRIPTION
This PR is aimed at making the provider able to connect to oVirt APIs as a non-admin user.

Please see https://github.com/imjoey/ovirt-engine-sdk-go/pull/127 for further details.