### PR TITLE
doc: Add website

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,7 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
+WEBSITE_REPO=github.com/hashicorp/terraform-website
+PKG_NAME=ovirt
 
 default: build
 
@@ -52,10 +54,25 @@ vendor-status:
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
-		echo "  make test-compile TEST=./ovirt"; \
+		echo "  make test-compile TEST=./$(PKG_NAME)"; \
 		exit 1; \
 	fi
 	go test -c $(TEST) $(TESTARGS)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile tf-fmt tf-fmtcheck
+website:
+ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
+	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
+	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
+endif
+	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
+
+website-test:
+ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
+	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
+	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
+endif
+	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
+
+
+.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile tf-fmt tf-fmtcheck website website-test
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ provider "ovirt" {
   * ovirt_storagedomains
   * ovirt_vnic_profiles
 
+Provider Documents
+--------------
+Currently the documents for this provider is not hosted by the offcial site [Terraform Providers](https://www.terraform.io/docs/providers/index.html). Please enter the provider directory and build the website locallly.
+
+```sh
+$ cd $GOPATH/src/github.com/imjoey/terraform-provider-ovirt
+$ make website
+```
+
+The commands above will start a docker-based web server powered by [Middleman](https://middlemanapp.com/), which hosts the documents in `website` directory. Simply open `http://localhost:4567/docs/providers/ovirt` and enjoy them.
+
 
 Disclaimer
 ---------

--- a/website/docs/d/clusters.html.markdown
+++ b/website/docs/d/clusters.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_clusters"
+sidebar_current: "docs-ovirt-datasource-clusters"
+description: |-
+  Provides details about oVirt clusters
+---
+
+# Data Source: ovirt\_clusters
+
+The oVirt Clusters data source allows access to details of list of clusters within oVirt.
+
+## Example Usage
+
+```hcl
+data "ovirt_clusters" "filtered_clusters" {
+    name_regex = "^default*"
+	
+    search     = {
+	  criteria       = "architecture = x86_64 and Storage.name = data"
+	  max            = 2
+	  case_sensitive = false
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) The fully functional regular expression for name
+* `search` - (Optional) The general search criteria representation, fitting the rules of [Searching](http://ovirt.github.io/ovirt-engine-api-model/master/#_searching)
+    * criteria - (Optional) The criteria for searching, using the same syntax as the oVirt query language
+    * max - (Optional) The maximum amount of objects returned. If not specified, the search will return all the objects.
+    * case_sensitive - (Optional) If the search are case sensitive, default value is `false`
+
+> The `search.criteria` also supports asterisk for searching by name, to indicate that any string matches, including the empty string. For example, the criteria `search=name=myobj*` will return all the objects with names beginning with `myobj`, such as `myobj2`, `myobj-test`. So, you could use `name_regex` for searching by complicated regular expression, and `search.criteria` for simple case accordingly.
+
+## Attributes Reference
+
+`clusters` is set to the wrapper of the found clusters. Each item of `clusters` contains the following attributes exported:
+
+* `id` - The ID of oVirt Cluster
+* `name` - The name of oVirt Cluster
+* `description` - The description of oVirt Cluster
+* `datacenter_id` - The ID of oVirt Datacenter the cluster belongs to

--- a/website/docs/d/datacenters.html.markdown
+++ b/website/docs/d/datacenters.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_datacenters"
+sidebar_current: "docs-ovirt-datasource-datacenters"
+description: |-
+  Provides details about oVirt datacenters
+---
+
+# Data Source: ovirt\_datacenters
+
+The oVirt Datacenters data source allows access to details of list of datacenters within oVirt.
+
+## Example Usage
+
+```hcl
+data "ovirt_datacenters" "filtered_datacenters" {
+    name_regex = "^default*"
+	
+    search     = {
+	  criteria       = "status = up and Storage.name = data"
+	  max            = 2
+	  case_sensitive = false
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) The fully functional regular expression for name
+* `search` - (Optional) The general search criteria representation, fitting the rules of [Searching](http://ovirt.github.io/ovirt-engine-api-model/master/#_searching)
+    * criteria - (Optional) The criteria for searching, using the same syntax as the oVirt query language
+    * max - (Optional) The maximum amount of objects returned. If not specified, the search will return all the objects.
+    * case_sensitive - (Optional) If the search are case sensitive, default value is `false`
+
+> The `search.criteria` also supports asterisk for searching by name, to indicate that any string matches, including the empty string. For example, the criteria `search=name=myobj*` will return all the objects with names beginning with `myobj`, such as `myobj2`, `myobj-test`. So, you could use `name_regex` for searching by complicated regular expression, and `search.criteria` for simple case accordingly.
+
+## Attributes Reference
+
+`datacenters` is set to the wrapper of the found datacenters. Each item of `datacenters` contains the following attributes exported:
+
+* `id` - The ID of oVirt Datacenter
+* `name` - The name of oVirt Datacenter
+* `status` - The status of oVirt Datacenter
+* `local` - Whether it uses local storage
+* `quota_mode` - The type of quota mode

--- a/website/docs/d/disks.html.markdown
+++ b/website/docs/d/disks.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_disks"
+sidebar_current: "docs-ovirt-datasource-disks"
+description: |-
+  Provides details about oVirt disks
+---
+
+# Data Source: ovirt\_disks
+
+The oVirt Disks data source allows access to details of list of disks within oVirt.
+
+## Example Usage
+
+```hcl
+data "ovirt_disks" "filtered_disks" {
+    name_regex = "^test_disk*"
+
+    search     = {
+	  criteria       = "name = test_disk1 and provisioned_size > 1024000000"
+	  max            = 2
+	  case_sensitive = false
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) The fully functional regular expression for name
+* `search` - (Optional) The general search criteria representation, fitting the rules of [Searching](http://ovirt.github.io/ovirt-engine-api-model/master/#_searching)
+    * criteria - (Optional) The criteria for searching, using the same syntax as the oVirt query language
+    * max - (Optional) The maximum amount of objects returned. If not specified, the search will return all the objects.
+    * case_sensitive - (Optional) If the search are case sensitive, default value is `false`
+
+> The `search.criteria` also supports asterisk for searching by name, to indicate that any string matches, including the empty string. For example, the criteria `search=name=myobj*` will return all the objects with names beginning with `myobj`, such as `myobj2`, `myobj-test`. So, you could use `name_regex` for searching by complicated regular expression, and `search.criteria` for simple case accordingly.
+
+## Attributes Reference
+
+`disks` is set to the wrapper of the found disks. Each item of `disks` contains the following attributes exported:
+
+* `id` - The ID of oVirt Disk
+* `name` - The name of oVirt Disk
+* `alias` - The alias of oVirt Disk
+* `format` - The format of oVirt Disk
+* `quota_id` - The ID of quota of oVirt Disk
+* `storage_domain_id` - The ID of storage domain the Disk belongs to
+* `size` - The provisioned size of oVirt Disk
+* `sharable` - Whether oVirt Disk could be attached to multiple vms
+* `sparse` - Whether the physical storage for oVirt Disk should not be preallocated

--- a/website/docs/d/networks.html.markdown
+++ b/website/docs/d/networks.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_networks"
+sidebar_current: "docs-ovirt-datasource-networks"
+description: |-
+  Provides details about oVirt networks
+---
+
+# Data Source: ovirt\_networks
+
+The oVirt Networks data source allows access to details of list of networks within oVirt.
+
+## Example Usage
+
+```hcl
+data "ovirt_networks" "filtered_networks" {
+    name_regex = "^ovirtmgmt-t*"
+	
+    search     = {
+	  criteria       = "datacenter = Default and name = ovirtmgmt-test"
+	  max            = 2
+	  case_sensitive = false
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) The fully functional regular expression for name
+* `search` - (Optional) The general search criteria representation, fitting the rules of [Searching](http://ovirt.github.io/ovirt-engine-api-model/master/#_searching)
+    * criteria - (Optional) The criteria for searching, using the same syntax as the oVirt query language
+    * max - (Optional) The maximum amount of objects returned. If not specified, the search will return all the objects.
+    * case_sensitive - (Optional) If the search are case sensitive, default value is `false`
+
+> The `search.criteria` also supports asterisk for searching by name, to indicate that any string matches, including the empty string. For example, the criteria `search=name=myobj*` will return all the objects with names beginning with `myobj`, such as `myobj2`, `myobj-test`. So, you could use `name_regex` for searching by complicated regular expression, and `search.criteria` for simple case accordingly.
+
+## Attributes Reference
+
+`networks` is set to the wrapper of the found networks. Each item of `networks` contains the following attributes exported:
+
+* `id` - The ID of oVirt Network
+* `name` - The name of oVirt Network
+* `datacenter_id` - The ID of oVirt Datacenter the Network belongs to
+* `description` - The description of oVirt Network
+* `vlan_id` - The vlan tag
+* `mtu` - The mtu of oVirt Network

--- a/website/docs/d/storagedomains.html.markdown
+++ b/website/docs/d/storagedomains.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_storagedomains"
+sidebar_current: "docs-ovirt-datasource-storagedomains"
+description: |-
+  Provides details about oVirt storagedomains
+---
+
+# Data Source: ovirt\_storagedomains
+
+The oVirt Storagedomains data source allows access to details of list of storagedomains within oVirt.
+
+## Example Usage
+
+```hcl
+data "ovirt_storagedomains" "filtered_storagedomains" {
+    name_regex = "^MAIN_dat.*|^DEV_dat.*"
+
+    search     = {
+	  criteria       = "status != unattached and name = DS_INTERNAL and datacenter = MY_DC"
+	  max            = 2
+	  case_sensitive = false
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) The fully functional regular expression for name
+* `search` - (Optional) The general search criteria representation, fitting the rules of [Searching](http://ovirt.github.io/ovirt-engine-api-model/master/#_searching)
+    * criteria - (Optional) The criteria for searching, using the same syntax as the oVirt query language
+    * max - (Optional) The maximum amount of objects returned. If not specified, the search will return all the objects.
+    * case_sensitive - (Optional) If the search are case sensitive, default value is `false`
+
+> The `search.criteria` also supports asterisk for searching by name, to indicate that any string matches, including the empty string. For example, the criteria `search=name=myobj*` will return all the objects with names beginning with `myobj`, such as `myobj2`, `myobj-test`. So, you could use `name_regex` for searching by complicated regular expression, and `search.criteria` for simple case accordingly.
+
+## Attributes Reference
+
+`storagedomains` is set to the wrapper of the found storagedomains. Each item of `storagedomains` contains the following attributes exported:
+
+* `id` - The ID of oVirt Storagedomain
+* `name` - The name of oVirt Storagedomain
+* `status` - The status of oVirt Storagedomain
+* `external_status` - The external status of oVirt Storagedomain
+* `type` - The type of oVirt Storagedomain
+* `description` - The description of oVirt Storagedomain
+* `datacenter_id` - The ID of oVirt Datacenter the Storagedomain belongs to

--- a/website/docs/d/vnic_profiles.html.markdown
+++ b/website/docs/d/vnic_profiles.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_vnic_profiles"
+sidebar_current: "docs-ovirt-datasource-vnic-profiles"
+description: |-
+  Provides details about oVirt vnic profiles
+---
+
+# Data Source: ovirt\_vnic\_profiles
+
+The oVirt vNIC profiles data source allows access to details of list of vNIC profiles within oVirt.
+
+## Example Usage
+
+```hcl
+data "ovirt_vnic_profiles" "filtered_vnic_profiles" {
+	name_regex = ".*mirror$"
+	network_id = "649f2d61-7f23-477b-93bd-d55f974d8bc8"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) The fully functional regular expression for name
+* `network_id` - (Optional) The ID of network the vnic profile belongs to
+
+> This data source dose not support for the regular oVirt query language.
+
+## Attributes Reference
+
+`vnic_profiles` is set to the wrapper of the found vnic profiles. Each item of `vnic_profiles` contains the following attributes exported:
+
+* `id` - The ID of oVirt vNIC profile
+* `name` - The name of oVirt vNIC profile
+* `network_id` - The ID of network the vNIC profile applies to
+* `migratable` - Whether `pass_through` vNIC is migratable
+* `port_mirroring` - Whether port mirroring is enabled

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "ovirt"
+page_title: "Provider: oVirt"
+sidebar_current: "docs-ovirt-index"
+description: |-
+  The oVirt provider is used to interact with the many resources supported by oVirt. The provider needs to be configured with the proper credentials before it can be used.
+---
+
+# oVirt Provider
+The oVirt provider is used to interact with the many resources supported by oVirt. The provider needs to be configured with the proper credentials before it can be used.
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+```hcl
+# Configure the oVirt Provider
+provider "ovirt" {
+  url      = "https://engine-api/ovirt-engine/api"
+  username = "admin@internal"
+  password = "thepassword"
+  headers  {
+      filter      = true
+      all_content = true
+  }
+}
+
+# Create a VM
+resource "ovirt_vm" "test-vm" {
+    # ...
+}
+```
+
+## Configuration Reference
+
+The following arguments are supported:
+
+* `url` - (Required) The oVirt engine API URL. If omitted, the `OVIRT_URL` environment variable is used.
+* `username` - (Required) The username for accessing oVirt engine API. If omitted, the `OVIRT_USERNAME` environment variable is used.
+* `password` - (Required) The password of the user for accessing oVirt engine API. If omitted, the `OVIRT_PASSWORD` environment variable is used.
+* `headers` - (Optional) A bunch of key-value pairs as the headers of the HTTP connection. The headers will be sent along with each API request, and could be overwrote with the header values specified in individual request.

--- a/website/docs/r/datacenter.html.markdown
+++ b/website/docs/r/datacenter.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_datacenter"
+sidebar_current: "docs-ovirt-resource-datacenter"
+description: |-
+  Manages a Datacenter resource within oVirt.
+---
+
+# ovirt\_datacenter
+
+Manages a Datacenter resource within oVirt.
+
+## Example Usage
+
+```hcl
+resource "ovirt_datacenter" "dc" {
+  name        = "mydc"
+  description = "my new dc"
+  local       = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the datacenter. Changing this updates the datacenter's name.
+* `description` - (Optional) A description of the datacenter. Changing this updates the datacenter's description.
+* `local` - (Required) A flag to indicate if the datacener uses local storage. Changing this update the datacenter's local flag.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - See Argument Reference above
+* `description` - See Argument Reference above
+* `local` - See Argument Reference above
+
+## Import
+
+Datacenters can be imported using the `id`, e.g.
+
+```
+$ terraform import ovirt_datacenter.dc 43631f2d-2558-4a42-adaa-2e9807144dc8
+```

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_disk"
+sidebar_current: "docs-ovirt-resource-disk"
+description: |-
+  Manages a Disk resource within oVirt.
+---
+
+# ovirt\_disk
+
+Manages a Disk resource within oVirt.
+
+## Example Usage
+
+```hcl
+resource "ovirt_disk" "disk" {
+  name              = "mydisk"
+  alias             = "mydisk-alias"
+  format            = "raw"
+  quota_id          = "dbbd5819-efa9-4383-9aad-55330841ad3c"
+  storage_domain_id = "fe98758d-60f8-4206-8ffc-f772e906d752"
+  size              = 60
+  shareable         = false
+  sparse            = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the disk. Changing this updates the disk's name.
+* `alias` - (Optional) A alais for the disk. Changing this updates the disk's alias.
+* `format` - (Required) The format of the disk. Valid valus are `cow` and `raw`. Changing this creates a new disk.
+* `quota_id` - (Optional) The ID of quota applied to the disk. Changing this creates a new disk.
+* `storage_domain_id` - (Required) The ID of storage domain the disk residents. Changing this creates a new disk.
+* `size` - (Required) The size of the disk to create (in gigabytes). Changing this updates the disk's size and only the size extention is supported.
+* `shareable` - (Optional) The flag to indicate whether the disk could be attached to multiple vms. Default is `false`. Changing this creates a new disk.
+* `sparse` - (Optional) The flag to indicate whether the physical storage for the disk should not be preallocated. Changing this creates a new disk.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - See Argument Reference above
+* `alias` - See Argument Reference above
+* `format` - See Argument Reference above
+* `quota_id` - See Argument Reference above
+* `storage_domain_id` - See Argument Reference above
+* `size` - See Argument Reference above
+* `shareable` - See Argument Reference above
+* `sparse` - See Argument Reference above
+
+## Import
+
+Disks can be imported using the `id`, e.g.
+
+```
+$ terraform import ovirt_disk.disk 67f88160-396b-441b-8824-f2c22e80bf82
+```

--- a/website/docs/r/disk_attachment.html.markdown
+++ b/website/docs/r/disk_attachment.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_disk_attachment"
+sidebar_current: "docs-ovirt-resource-disk-attachment"
+description: |-
+  Manages a Disk attachment resource within oVirt.
+---
+
+# ovirt\_disk\_attachment
+
+Manages a Disk attachment resource within oVirt.
+
+## Example Usage
+
+```hcl
+resource "ovirt_disk_attachment" "diskattachment" {
+  vm_id                = "5ba458c1-01fd-00eb-0140-000000000351"
+  disk_id              = "67f88160-396b-441b-8824-f2c22e80bf82"
+  active               = true
+  bootable             = true
+  interface            = "virtio"
+  pass_discard         = true
+  read_only            = true
+  use_scsi_reservation = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vm_id` - (Required) The ID of VM the disk attached to. Changing this creates a new disk attachment.
+* `disk_id` - (Required) The ID of attached disk. Changing this creates a new disk attachment.
+* `active` - (Optional) The flag to indicate whether the disk is active. Default is `true`. Changing this updates the attachment's active.
+* `bootable` - (Optional) The flag to indicate whether the disk is bootable. Default is `false`. Changing this updates the attachment's bootable.
+* `interface` - (Required) The interface of the attachment. Valid values are `ide`, `sata`, `spapr_vscsi`, `virtio` and `virtio_scsi`. Changing this creates a new attachment.
+* `pass_discard` - (Optional) The flag to indicate whether the VM passes discard commands to the storage. Changing this creates a new attachment.
+* `read_only` - (Optional) The flag to indicate whether the disk is connected to the VM as read only. Default is `false`. Changing this creates a new attachment.
+* `use_scsi_reservation` - (Optional) The flag to indicate whether SCSI reservation is enabled for this disk. Default is `false`. Changing this creates a new attachment.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `vm_id` - See Argument Reference above
+* `disk_id` - See Argument Reference above
+* `active` - See Argument Reference above
+* `bootable` - See Argument Reference above
+* `interface` - See Argument Reference above
+* `pass_discard` - See Argument Reference above
+* `read_only` - See Argument Reference above
+* `use_scsi_reservation` - See Argument Reference above
+
+## Import
+
+Disk attachment can be imported using the `id`, e.g.
+
+```
+$ terraform import ovirt_disk_attachment.diskattachment 3d88d40c-3230-4266-9228-fff5c1348081
+```

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_network"
+sidebar_current: "docs-ovirt-resource-network"
+description: |-
+  Manages a Network resource within oVirt.
+---
+
+# ovirt\_network
+
+Manages a network resource within oVirt.
+
+## Example Usage
+
+```hcl
+resource "ovirt_network" "network" {
+  name          = "mynetwork"
+  description   = "my new network"
+  datacenter_id = "00bfb5f6-1641-4fe5-b634-9f53c36f753b"
+  vlan_id       = 488
+  mtu           = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the network. Changing this updates the network's name.
+* `description` - (Optional) A description of the network. Changing this updates the network's description.
+* `datacenter_id` - (Required) The ID of datacenter the network belongs to. Changing this updates the network's datacenter_id.
+* `vlan_id` - (Optional) The vlan tag of the network. Changing this updates the network's vlan_id.
+* `mtu` - (Optional) A mtu of the network. Changing this updates the network's mtu.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - See Argument Reference above
+* `description` - See Argument Reference above
+* `datacenter_id` - See Argument Reference above
+* `vlan_id` - See Argument Reference above
+* `mtu` - See Argument Reference above
+
+## Import
+
+Networks can be imported using the `id`, e.g.
+
+```
+$ terraform import ovirt_network.network 381e3d4f-dc1e-427d-9e07-9ce72a188304
+```

--- a/website/docs/r/vm.html.markdown
+++ b/website/docs/r/vm.html.markdown
@@ -1,0 +1,220 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_vm"
+sidebar_current: "docs-ovirt-resource-vm"
+description: |-
+  Manages a VM resource within oVirt.
+---
+
+# ovirt\_vm
+
+Manages a VM resource within oVirt.
+
+## Example Usage
+
+### Boot VM From an Existing Template (Disk)
+
+```hcl
+resource "ovirt_vm" "vm" {
+  name        = "my_vm"
+  cluster_id  = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
+  memory      = 4096
+  # there has one or more disks in the specified template
+  template_id = "5ba458ca-00a4-0358-00cb-000000000223"
+}
+```
+
+### Boot VM From a New Disk
+
+```hcl
+resource "ovirt_vm" "vm" {
+  name        = "my_vm"
+  cluster_id  = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
+  memory      = 4096                    # in megabytes
+
+  block_device {
+    disk_id   = "${ovirt_disk.boot_disk_1.id}"
+    interface = "virtio"
+  }
+
+}
+
+resource "ovirt_disk" "boot_disk_1" {
+  name              = "boot_disk_1"
+  alias             = "boot_disk_1"
+  size              = 60                  # in gigabytes
+  format            = "cow"
+  storage_domain_id = "5ba458ca-00a4-0358-00cb-000000000223"
+  sparse            = true
+}
+```
+
+### Boot VM From an Existing Disk
+
+```hcl
+resource "ovirt_vm" "vm" {
+  name        = "my_vm"
+  cluster_id  = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
+  memory      = 4096                    # in megabytes
+
+  block_device {
+    disk_id   = "${data.boot_disk.disks.0.id}"
+    interface = "virtio"
+  }
+
+}
+
+data "ovirt_disks" "boot_disk" {
+    name_regex = "boot_disk_1"
+}
+```
+
+### Attach a New Disks to VM
+
+```hcl
+resource "ovirt_vm" "vm" {
+  name        = "my_vm"
+  cluster_id  = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
+  memory      = 4096                      # in megabytes
+  # there has one or more disks in the specified template
+  template_id = "5ba458ca-00a4-0358-00cb-000000000223"
+}
+
+resource "ovirt_disk" "attached_disk_1" {
+  name              = "attached_disk_1"
+  alias             = "attached_disk_1"
+  size              = 60                  # in gigabytes
+  format            = "cow"
+  storage_domain_id = "5ba458ca-00a4-0358-00cb-000000000223"
+  sparse            = true
+}
+
+resource "ovirt_disk_attachment" "attachment" {
+  vm_id     = "${ovirt_vm.vm.id}"
+  disk_id   = "${ovirt_disk.attached_disk_1.id}"
+  bootable  = false
+  interface = "virtio"
+  active    = true
+  read_only = false
+}
+```
+
+### Attach multiple vNICs to VM
+
+```hcl
+resource "ovirt_vm" "vm" {
+  name        = "my_vm"
+  cluster_id  = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
+  memory      = 4096                    # in megabytes
+  # there has one or more disks in the specified template
+  template_id = "5ba458ca-00a4-0358-00cb-000000000223"
+}
+
+resource "ovirt_vnic" "nic1" {
+  name            = "nic1"
+  vm_id           = "${ovirt_vm.vm.id}"
+  vnic_profile_id = "ce6f1f2e-7262-40f6-a005-531c9cec0f28"
+}
+
+resource "ovirt_vnic" "nic2" {
+  name            = "nic2"
+  vm_id           = "${ovirt_vm.vm.id}"
+  vnic_profile_id = "ce6f1f2e-7262-40f6-a005-531c9cec0f28"
+}
+```
+
+### VM with User Data
+
+```hcl
+resource "ovirt_vm" "my_vm_1" {
+  name        = "my_vm_1"
+  cluster_id  = "b0280bd4-4152-42ad-aa37-1e73ab30b0da"
+  template_id = "5ba458ca-00a4-0358-00cb-000000000223"
+  memory      = 4096                         # in megabytes
+
+  initialization {
+    authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
+	host_name          = "vm-basic-updated"
+	timezone           = "Asia/Shanghai"
+	user_name          = "root"
+	custom_script      = "echo hello2"
+	dns_search         = "university.edu"
+	dns_servers        = "8.8.8.8"
+
+    nic_configuration {
+      label      = "eth0"
+      boot_proto = "static"
+      address    = "10.1.60.60"
+      gateway    = "10.1.60.1"
+      netmask    = "255.255.255.0"
+    }
+
+    nic_configuration {
+      label      = "eth1"
+      boot_proto = "static"
+      address    = "10.1.60.61"
+      gateway    = "10.1.60.1"
+      netmask    = "255.255.255.0"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the VM. Changing this creates a new VM.
+* `cluster_id` - (Required) The ID of cluster the VM belongs to. Changing this creates a new VM.
+* `template_id` - (Optional) The ID of template the VM based on. Default is `00000000-0000-0000-0000-000000000000`. Changing this creates a new VM.
+* `memory` - (Optional) The amount of memory of the VM (in metabytes). Changing this creates a new VM.
+* `cores` - (Optional) The amount of cores. Default is `1`. Changing this creates a new VM.
+* `sockets` - (Optional) The amount of sockets. Default is `1`. Changing this creates a new VM.
+* `threads` - (Optional) The amount of threads. Default is `1`. Changing this creates a new VM.
+* `block_device` - (Optional) Configurations of bootable disk block device. The block_device structure is documented below. Changing this creates a new VM. You can specify at most one block_device.
+* `initialization` - (Optional) Configurations of initialization. The initialization structure is documented below. Changint this updates the VM's initialization. You can specify at most one initialization.
+
+The `block_device` block supports:
+
+* `disk_id` - (Required) The ID of attached disk. Changing this creates a new disk attachment.
+* `active` - (Optional) The flag to indicate whether the disk is active. Default is `true`. Changing this updates the attachment's active.
+* `bootable` - (Optional) The flag to indicate whether the disk is bootable. Default is `false`. Changing this updates the attachment's bootable.
+* `interface` - (Required) The interface of the attachment. Valid values are `ide`, `sata`, `spapr_vscsi`, `virtio` and `virtio_scsi`. Changing this creates a new attachment.
+* `pass_discard` - (Optional) The flag to indicate whether the VM passes discard commands to the storage. Changing this creates a new attachment.
+* `read_only` - (Optional) The flag to indicate whether the disk is connected to the VM as read only. Default is `false`. Changing this creates a new attachment.
+* `use_scsi_reservation` - (Optional) The flag to indicate whether SCSI reservation is enabled for this disk. Default is `false`. Changing this creates a new attachment.
+
+The `initialization` block supports:
+
+* `host_name` - (Optional) Set the hostname for the VM.
+* `timezone` - (Optional) Set the timezone for the VM.
+* `user_name` - (Optional) Set the user name for the VM.
+* `custom_scripit` - (Optional) Set the custom script for the VM.
+* `dns_servers` - (Optional) Set the dns server for the VM.
+* `dns_search` - (Optional) Set the dns server for the VM.
+* `nic_configuration` - (Optional) Configurations to initilize the vNICs in VM. The nic_configuration structure is documented below. 
+* `authorized_ssh_key` - (Optional) Set the ssh key for the VM. Default is `""`.
+
+The `nic_configuration` block supports:
+
+* `label` - (Required) Speficy the vNIC to apply this configuration.
+* `boot_proto` - (Required) Set the boot protocol for the vNIC configuration. Valid values are `autoconf`, `dhcp`, `none` and `static`.
+* `address` - (Optional) Set the IP address for the vNIC.
+* `netmask` - (Optional) Set the netmask for the vNIC.
+* `gateway` - (Optional) Set the gateway for the vNIC.
+* `on_boot` - (Optional) The flag to indicate whether the vNIC will be activated at VM booting. Default is `true`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - See Argument Reference above
+* `status` - The detected status of the VM.
+* `cluster_id` - See Argument Reference above
+* `template_id` - See Argument Reference above
+* `memory` - See Argument Reference above
+* `cores` - See Argument Reference above
+* `sockets` - See Argument Reference above
+* `threads` - See Argument Reference above
+* `block_device` - See Argument Reference above
+* `initialization` - See Argument Reference above

--- a/website/docs/r/vnic.html.markdown
+++ b/website/docs/r/vnic.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_vnic"
+sidebar_current: "docs-ovirt-resource-vnic"
+description: |-
+  Manages a vNIC resource within oVirt.
+---
+
+# ovirt\_vnic
+
+Manages a vNIC resource within oVirt.
+
+## Example Usage
+
+```hcl
+resource "ovirt_vnic" "vnic" {
+  name            = "myvnic"
+  vm_id           = "fd0dc842-57d4-4ae4-82ea-3a16516fbef7"
+  vnic_profile_id = "3e7644a7-1f54-49b9-87e0-d46819fba4c5"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name of the vNIC. Changing this creates a new vNIC.
+* `vm_id` - (Required) The ID of vm the vNIC attached to. Changing this creates a new vNIC.
+* `vnic_profile_id` - (Required) The ID of the vNIC profile applied to the vNIC. Changing this create a new vNIC.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - See Argument Reference above
+* `vm_id` - See Argument Reference above
+* `vnic_profile_id` - See Argument Reference above
+
+## Import
+
+vNIC can be imported using the `id`, e.g.
+
+```
+$ terraform import ovirt_vnic.vnic 43631f2d-2558-4a42-adaa-2e9807144dc8
+```

--- a/website/docs/r/vnic_profile.html.markdown
+++ b/website/docs/r/vnic_profile.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_vnic_profile"
+sidebar_current: "docs-ovirt-resource-vnic-profile"
+description: |-
+  Manages a vNIC profile resource within oVirt.
+---
+
+# ovirt\_vnic\_profile
+
+Manages a vNIC profile resource within oVirt.
+
+## Example Usage
+
+```hcl
+resource "ovirt_vnic_profile" "vnicprofile" {
+  name           = "myvnicprofile"
+  migratable     = false
+  network_id     = "43631f2d-2558-4a42-adaa-2e9807144dc8"
+  port_mirroring = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name of the vNIC profile. Changing this updates the vNIC profile's name.
+* `network_id` - (Required) The ID of network the vNIC profile applies to. Changing this creates a new vNIC profile.
+* `migratable` - (Optional) A flag to indicate whether `pass_through` vNIC is migratable. Default is `false`. Changing this updates the vNIC profile's migratable.
+* `port_mirroring` - (Optional) A flag to indicate whether port mirroring is enabled. Default is `false`. Changing this updates the vNIC profile's port mirroring.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - See Argument Reference above
+* `network_id` - See Argument Reference above
+* `migratable` - See Argument Reference above
+* `port_mirroring` - See Argument Reference above
+
+## Import
+
+vNIC profiles can be imported using the `id`, e.g.
+
+```
+$ terraform import ovirt_vnic_profile.vnicprofile fe98758d-60f8-4206-8ffc-f772e906d752
+```

--- a/website/ovirt.erb
+++ b/website/ovirt.erb
@@ -1,0 +1,81 @@
+<% wrap_layout :inner do %>
+    <% content_for :sidebar do %>
+      <div class="docs-sidebar hidden-print affix-top" role="complementary">
+        <ul class="nav docs-sidenav">
+          <li<%= sidebar_current("docs-home") %>>
+            <a href="/docs/providers/index.html">All Providers</a>
+          </li>
+  
+          <li<%= sidebar_current("docs-ovirt-index") %>>
+            <a href="/docs/providers/ovirt/index.html">oVirt Provider</a>
+          </li>
+
+          <li<%= sidebar_current("docs-ovirt-datasource") %>>
+            <a href="#">Data Sources</a>
+            <ul class="nav nav-visible">
+              <li<%= sidebar_current("docs-ovirt-datasource-datacenters") %>>
+                <a href="/docs/providers/ovirt/d/datacenters.html">ovirt_datacenters</a>
+              </li>
+              <li<%= sidebar_current("docs-ovirt-datasource-clusters") %>>
+                <a href="/docs/providers/ovirt/d/clusters.html">ovirt_clusters</a>
+              </li>
+              <li<%= sidebar_current("docs-ovirt-datasource-storagedomains") %>>
+                <a href="/docs/providers/ovirt/d/storagedomains.html">ovirt_storagedomains</a>
+              </li>
+              <li<%= sidebar_current("docs-ovirt-datasource-disks") %>>
+                <a href="/docs/providers/ovirt/d/disks.html">ovirt_disks</a>
+              </li>
+              <li<%= sidebar_current("docs-ovirt-datasource-networks") %>>
+                <a href="/docs/providers/ovirt/d/networks.html">ovirt_networks</a>
+              </li>
+              <li<%= sidebar_current("docs-ovirt-datasource-vnic-profiles") %>>
+                <a href="/docs/providers/ovirt/d/vnic_profiles.html">ovirt_vnic_profiles</a>
+              </li>
+            </ul>
+          </li>
+
+          <li<%= sidebar_current("docs-ovirt-resource-compute") %>>
+            <a href="#">Compute Resources</a>
+            <ul class="nav nav-visible">
+              <li<%= sidebar_current("docs-ovirt-resource-datacenter") %>>
+                <a href="/docs/providers/ovirt/r/datacenter.html">ovirt_datacenter</a>
+              </li>
+              <li<%= sidebar_current("docs-ovirt-resource-vm") %>>
+                <a href="/docs/providers/ovirt/r/vm.html">ovirt_vm</a>
+              </li>
+            </ul>
+          </li>
+
+          <li<%= sidebar_current("docs-ovirt-resource-network") %>>
+            <a href="#">Network Resources</a>
+            <ul class="nav nav-visible">
+              <li<%= sidebar_current("docs-ovirt-resource-network") %>>
+                <a href="/docs/providers/ovirt/r/network.html">ovirt_network</a>
+              </li>
+              <li<%= sidebar_current("docs-ovirt-resource-vnic") %>>
+                <a href="/docs/providers/ovirt/r/vnic.html">ovirt_vnic</a>
+              </li>
+              <li<%= sidebar_current("docs-ovirt-resource-vnic-profile") %>>
+                <a href="/docs/providers/ovirt/r/vnic_profile.html">ovirt_vnic_profile</a>
+              </li>
+            </ul>
+          </li>
+
+          <li<%= sidebar_current("docs-ovirt-resource-storage") %>>
+            <a href="#">Storage Resources</a>
+            <ul class="nav nav-visible">
+              <li<%= sidebar_current("docs-ovirt-resource-disk") %>>
+                <a href="/docs/providers/ovirt/r/disk.html">ovirt_disk</a>
+              </li>
+              <li<%= sidebar_current("docs-ovirt-resource-disk-attachment") %>>
+                <a href="/docs/providers/ovirt/r/disk_attachment.html">ovirt_disk_attachment</a>
+              </li>
+            </ul>
+          </li>
+
+        </ul>
+      </div>
+    <% end %>
+  
+    <%= yield %>
+    <% end %>


### PR DESCRIPTION
Aims at #73 to add more examples and documents.

Changes proposed in this pull request:

* Add basic `website` infrastructure
* Add `website` and `website-test` targets in `GNUmakefile`
* Add documents for provider
* Add documents for all of the existing resources
* Add documents for all of the existing data sources

> Now in my local dev environment, I encounter the issue https://github.com/hashicorp/terraform-website/issues/3 . Currently I've no idea how to get a workaround, in order to provider documents ASAP, I just merge it blindly. If the website codes have errors, please open issues. 😄 
