### PR TITLE
Add high_availability and nics on creation features

### DIFF
--- a/ovirt/resource_ovirt_vm_test.go
+++ b/ovirt/resource_ovirt_vm_test.go
@@ -316,6 +316,7 @@ resource "ovirt_vm" "vm" {
 	name        = "testAccVMTemplate"
 	cluster_id  = "%s"
 	template_id = "%s"
+	high_availability = true
 }
 `, clusterID, templateID)
 }


### PR DESCRIPTION
Changes proposed in this pull request:

* Add `high_availability` param to `ovirt_vm` 
* Add possibility to create VM nics upon VM creation; this prevents nics to be added after VM has been launched, avoiding a race condition that let cloud-init run before network cards have been attached to the VM

@imjoey I'm unable to run acceptance tests at the moment, as I don't have access to my oVirt test deployment. Could you please help? Thanks