### PR TITLE
Update go-sdk dependency library to v4.0.5

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -557,12 +557,12 @@
   version = "v1.13.0"
 
 [[projects]]
-  digest = "1:09dff2a54ad9d4410dd10f3bda5b12d939275e1d22c6ed857a2b3c556cf8891b"
+  digest = "1:6d5b4ea993af841aff11f2e4b361cc82746e7d1ca6c3478994f15fbdbc9ea02e"
   name = "gopkg.in/imjoey/go-ovirt.v4"
   packages = ["."]
   pruneopts = "UT"
-  revision = "06fe98be0c975223a40720a0e1c726fc20bf1f78"
-  version = "v4.0.4"
+  revision = "5d2ceb0bc7deab08530d992c853a75da277aae01"
+  version = "v4.0.5"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "gopkg.in/imjoey/go-ovirt.v4"
-  version = "4.0.4"
+  version = "4.0.5"
 
 [prune]
   go-tests = true

--- a/vendor/gopkg.in/imjoey/go-ovirt.v4/readers.go
+++ b/vendor/gopkg.in/imjoey/go-ovirt.v4/readers.go
@@ -4876,6 +4876,12 @@ func XMLVmBaseReadOne(reader *XMLReader, start *xml.StartElement, expectedTag st
 					return nil, err
 				}
 				builder.MigrationDowntime(v)
+			case "multi_queues_enabled":
+				v, err := reader.ReadBool(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.MultiQueuesEnabled(v)
 			case "name":
 				v, err := reader.ReadString(&t)
 				if err != nil {
@@ -7563,6 +7569,18 @@ func XMLOpenStackNetworkProviderReadOne(reader *XMLReader, start *xml.StartEleme
 					return nil, err
 				}
 				builder.PluginType(v)
+			case "project_domain_name":
+				v, err := reader.ReadString(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.ProjectDomainName(v)
+			case "project_name":
+				v, err := reader.ReadString(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.ProjectName(v)
 			case "properties":
 				v, err := XMLPropertyReadMany(reader, &t)
 				if err != nil {
@@ -7612,6 +7630,12 @@ func XMLOpenStackNetworkProviderReadOne(reader *XMLReader, start *xml.StartEleme
 					return nil, err
 				}
 				builder.Url(v)
+			case "user_domain_name":
+				v, err := reader.ReadString(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.UserDomainName(v)
 			case "username":
 				v, err := reader.ReadString(&t)
 				if err != nil {
@@ -11338,6 +11362,12 @@ func XMLImageTransferReadOne(reader *XMLReader, start *xml.StartElement, expecte
 					return nil, err
 				}
 				builder.Image(v)
+			case "inactivity_timeout":
+				v, err := reader.ReadInt64(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.InactivityTimeout(v)
 			case "name":
 				v, err := reader.ReadString(&t)
 				if err != nil {
@@ -16152,6 +16182,12 @@ func XMLInstanceTypeReadOne(reader *XMLReader, start *xml.StartElement, expected
 					return nil, err
 				}
 				builder.MigrationDowntime(v)
+			case "multi_queues_enabled":
+				v, err := reader.ReadBool(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.MultiQueuesEnabled(v)
 			case "name":
 				v, err := reader.ReadString(&t)
 				if err != nil {
@@ -17417,6 +17453,12 @@ func XMLSnapshotReadOne(reader *XMLReader, start *xml.StartElement, expectedTag 
 					return nil, err
 				}
 				builder.MigrationDowntime(v)
+			case "multi_queues_enabled":
+				v, err := reader.ReadBool(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.MultiQueuesEnabled(v)
 			case "name":
 				v, err := reader.ReadString(&t)
 				if err != nil {
@@ -22721,6 +22763,12 @@ func XMLTemplateReadOne(reader *XMLReader, start *xml.StartElement, expectedTag 
 					return nil, err
 				}
 				builder.MigrationDowntime(v)
+			case "multi_queues_enabled":
+				v, err := reader.ReadBool(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.MultiQueuesEnabled(v)
 			case "name":
 				v, err := reader.ReadString(&t)
 				if err != nil {
@@ -29766,6 +29814,12 @@ func XMLStorageConnectionReadOne(reader *XMLReader, start *xml.StartElement, exp
 					return nil, err
 				}
 				builder.Description(v)
+			case "gluster_volume":
+				v, err := XMLGlusterVolumeReadOne(reader, &t, "gluster_volume")
+				if err != nil {
+					return nil, err
+				}
+				builder.GlusterVolume(v)
 			case "host":
 				v, err := XMLHostReadOne(reader, &t, "host")
 				if err != nil {
@@ -32015,6 +32069,12 @@ func XMLHostReadOne(reader *XMLReader, start *xml.StartElement, expectedTag stri
 					return nil, err
 				}
 				builder.NetworkAttachments(v)
+			case "network_operation_in_progress":
+				v, err := reader.ReadBool(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.NetworkOperationInProgress(v)
 			case "nics":
 				v, err := XMLHostNicReadMany(reader, &t)
 				if err != nil {
@@ -32521,6 +32581,13 @@ func XMLOperatingSystemInfoReadOne(reader *XMLReader, start *xml.StartElement, e
 		switch t := t.(type) {
 		case xml.StartElement:
 			switch t.Name.Local {
+			case "architecture":
+				vp, err := XMLArchitectureReadOne(reader, &t)
+				v := *vp
+				if err != nil {
+					return nil, err
+				}
+				builder.Architecture(v)
 			case "comment":
 				v, err := reader.ReadString(&t)
 				if err != nil {
@@ -32912,6 +32979,12 @@ func XMLVmReadOne(reader *XMLReader, start *xml.StartElement, expectedTag string
 					return nil, err
 				}
 				builder.MigrationDowntime(v)
+			case "multi_queues_enabled":
+				v, err := reader.ReadBool(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.MultiQueuesEnabled(v)
 			case "name":
 				v, err := reader.ReadString(&t)
 				if err != nil {
@@ -36073,6 +36146,12 @@ func XMLActionReadOne(reader *XMLReader, start *xml.StartElement, expectedTag st
 					return nil, err
 				}
 				builder.RootPassword(v)
+			case "seal":
+				v, err := reader.ReadBool(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.Seal(v)
 			case "snapshot":
 				v, err := XMLSnapshotReadOne(reader, &t, "snapshot")
 				if err != nil {

--- a/vendor/gopkg.in/imjoey/go-ovirt.v4/services.go
+++ b/vendor/gopkg.in/imjoey/go-ovirt.v4/services.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"strings"
 )
@@ -176,6 +177,17 @@ func (p *jobsServiceAddRequest) Send() (*jobsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.jobsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.jobsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -423,6 +435,17 @@ func (p *jobsServiceListRequest) Send() (*jobsServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.jobsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.jobsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -661,6 +684,17 @@ func (p *dataCentersServiceAddRequest) Send() (*dataCentersServiceAddResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.dataCentersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.dataCentersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -907,6 +941,17 @@ func (p *dataCentersServiceListRequest) Send() (*dataCentersServiceListResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.dataCentersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.dataCentersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -1172,6 +1217,17 @@ func (p *permissionServiceGetRequest) Send() (*permissionServiceGetResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.permissionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.permissionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -1297,6 +1353,17 @@ func (p *permissionServiceRemoveRequest) Send() (*permissionServiceRemoveRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.permissionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.permissionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -1439,6 +1506,17 @@ func (p *storageServiceGetRequest) Send() (*storageServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -1607,6 +1685,17 @@ func (p *assignedTagsServiceAddRequest) Send() (*assignedTagsServiceAddResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedTagsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedTagsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -1782,6 +1871,17 @@ func (p *assignedTagsServiceListRequest) Send() (*assignedTagsServiceListRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedTagsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedTagsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -1979,6 +2079,17 @@ func (p *linkLayerDiscoveryProtocolServiceListRequest) Send() (*linkLayerDiscove
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.linkLayerDiscoveryProtocolService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.linkLayerDiscoveryProtocolService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -2184,6 +2295,17 @@ func (p *systemPermissionsServiceAddRequest) Send() (*systemPermissionsServiceAd
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -2408,6 +2530,17 @@ func (p *systemPermissionsServiceAddClusterPermissionRequest) Send() (*systemPer
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -2535,6 +2668,17 @@ func (p *systemPermissionsServiceAddDataCenterPermissionRequest) Send() (*system
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -2662,6 +2806,17 @@ func (p *systemPermissionsServiceAddGroupLevelRequest) Send() (*systemPermission
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -2789,6 +2944,17 @@ func (p *systemPermissionsServiceAddHostPermissionRequest) Send() (*systemPermis
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -2930,6 +3096,17 @@ func (p *systemPermissionsServiceListRequest) Send() (*systemPermissionsServiceL
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -3104,6 +3281,17 @@ func (p *systemPermissionsServiceAddStorageDomainPermissionRequest) Send() (*sys
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -3231,6 +3419,17 @@ func (p *systemPermissionsServiceAddTemplatePermissionRequest) Send() (*systemPe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -3358,6 +3557,17 @@ func (p *systemPermissionsServiceAddUserLevelRequest) Send() (*systemPermissions
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -3485,6 +3695,17 @@ func (p *systemPermissionsServiceAddVmPermissionRequest) Send() (*systemPermissi
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -3612,6 +3833,17 @@ func (p *systemPermissionsServiceAddVmPoolPermissionRequest) Send() (*systemPerm
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -3776,6 +4008,17 @@ func (p *schedulingPoliciesServiceAddRequest) Send() (*schedulingPoliciesService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.schedulingPoliciesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.schedulingPoliciesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -3925,6 +4168,17 @@ func (p *schedulingPoliciesServiceListRequest) Send() (*schedulingPoliciesServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.schedulingPoliciesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.schedulingPoliciesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -4093,6 +4347,17 @@ func (p *clusterNetworkServiceGetRequest) Send() (*clusterNetworkServiceGetRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -4211,6 +4476,17 @@ func (p *clusterNetworkServiceRemoveRequest) Send() (*clusterNetworkServiceRemov
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -4322,6 +4598,17 @@ func (p *clusterNetworkServiceUpdateRequest) Send() (*clusterNetworkServiceUpdat
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -4483,6 +4770,17 @@ func (p *templateCdromServiceGetRequest) Send() (*templateCdromServiceGetRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateCdromService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateCdromService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -4652,6 +4950,17 @@ func (p *networkAttachmentsServiceAddRequest) Send() (*networkAttachmentsService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkAttachmentsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkAttachmentsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -4791,6 +5100,17 @@ func (p *networkAttachmentsServiceListRequest) Send() (*networkAttachmentsServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkAttachmentsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkAttachmentsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -4957,6 +5277,17 @@ func (p *unmanagedNetworkServiceGetRequest) Send() (*unmanagedNetworkServiceGetR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.unmanagedNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.unmanagedNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -5082,6 +5413,17 @@ func (p *unmanagedNetworkServiceRemoveRequest) Send() (*unmanagedNetworkServiceR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.unmanagedNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.unmanagedNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -5227,6 +5569,17 @@ func (p *snapshotNicsServiceListRequest) Send() (*snapshotNicsServiceListRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotNicsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotNicsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -5420,6 +5773,17 @@ func (p *hostStorageServiceListRequest) Send() (*hostStorageServiceListResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostStorageService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostStorageService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -5643,6 +6007,17 @@ func (p *tagsServiceAddRequest) Send() (*tagsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.tagsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.tagsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -5857,6 +6232,17 @@ func (p *tagsServiceListRequest) Send() (*tagsServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.tagsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.tagsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -6156,6 +6542,17 @@ func (p *hostsServiceAddRequest) Send() (*hostsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -6451,6 +6848,17 @@ func (p *hostsServiceListRequest) Send() (*hostsServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -6641,6 +7049,17 @@ func (p *hostsServiceAddUsingRootPasswordRequest) Send() (*hostsServiceAddUsingR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -6786,6 +7205,17 @@ func (p *hostsServiceAddUsingSshRequest) Send() (*hostsServiceAddUsingSshRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -6948,6 +7378,17 @@ func (p *balancesServiceAddRequest) Send() (*balancesServiceAddResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.balancesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.balancesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -7097,6 +7538,17 @@ func (p *balancesServiceListRequest) Send() (*balancesServiceListResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.balancesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.balancesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -7263,6 +7715,17 @@ func (p *diskSnapshotServiceGetRequest) Send() (*diskSnapshotServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskSnapshotService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskSnapshotService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -7388,6 +7851,17 @@ func (p *diskSnapshotServiceRemoveRequest) Send() (*diskSnapshotServiceRemoveRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskSnapshotService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskSnapshotService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -7520,6 +7994,17 @@ func (p *storageDomainServerConnectionServiceGetRequest) Send() (*storageDomainS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainServerConnectionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainServerConnectionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -7646,6 +8131,17 @@ func (p *storageDomainServerConnectionServiceRemoveRequest) Send() (*storageDoma
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainServerConnectionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainServerConnectionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -7783,6 +8279,17 @@ func (p *openstackSubnetsServiceAddRequest) Send() (*openstackSubnetsServiceAddR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackSubnetsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackSubnetsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -7920,6 +8427,17 @@ func (p *openstackSubnetsServiceListRequest) Send() (*openstackSubnetsServiceLis
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackSubnetsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackSubnetsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -8086,6 +8604,17 @@ func (p *openstackVolumeTypeServiceGetRequest) Send() (*openstackVolumeTypeServi
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeTypeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeTypeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -8238,6 +8767,17 @@ func (p *openstackVolumeAuthenticationKeyServiceGetRequest) Send() (*openstackVo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeAuthenticationKeyService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeAuthenticationKeyService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -8363,6 +8903,17 @@ func (p *openstackVolumeAuthenticationKeyServiceRemoveRequest) Send() (*openstac
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeAuthenticationKeyService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeAuthenticationKeyService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -8472,6 +9023,17 @@ func (p *openstackVolumeAuthenticationKeyServiceUpdateRequest) Send() (*openstac
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeAuthenticationKeyService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeAuthenticationKeyService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -8551,7 +9113,7 @@ func NewOpenstackImageProvidersService(connection *Connection, path string) *ope
 }
 
 //
-// Add a new OpenStack image provider to the system.
+// Adds a new OpenStack image provider to the system.
 //
 type openstackImageProvidersServiceAddRequest struct {
 	openstackImageProvidersService *openstackImageProvidersService
@@ -8630,6 +9192,17 @@ func (p *openstackImageProvidersServiceAddRequest) Send() (*openstackImageProvid
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackImageProvidersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackImageProvidersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -8654,7 +9227,7 @@ func (p *openstackImageProvidersServiceAddRequest) MustSend() *openstackImagePro
 }
 
 //
-// Add a new OpenStack image provider to the system.
+// Adds a new OpenStack image provider to the system.
 //
 type openstackImageProvidersServiceAddResponse struct {
 	provider *OpenStackImageProvider
@@ -8675,7 +9248,7 @@ func (p *openstackImageProvidersServiceAddResponse) MustProvider() *OpenStackIma
 }
 
 //
-// Add a new OpenStack image provider to the system.
+// Adds a new OpenStack image provider to the system.
 //
 func (p *openstackImageProvidersService) Add() *openstackImageProvidersServiceAddRequest {
 	return &openstackImageProvidersServiceAddRequest{openstackImageProvidersService: p}
@@ -8683,7 +9256,7 @@ func (p *openstackImageProvidersService) Add() *openstackImageProvidersServiceAd
 
 //
 // Returns the list of providers.
-// The order of the returned list of providers isn't guaranteed.
+// The order of the returned list of providers is not guaranteed.
 //
 type openstackImageProvidersServiceListRequest struct {
 	openstackImageProvidersService *openstackImageProvidersService
@@ -8691,6 +9264,7 @@ type openstackImageProvidersServiceListRequest struct {
 	query                          map[string]string
 	follow                         *string
 	max                            *int64
+	search                         *string
 }
 
 func (p *openstackImageProvidersServiceListRequest) Header(key, value string) *openstackImageProvidersServiceListRequest {
@@ -8719,6 +9293,11 @@ func (p *openstackImageProvidersServiceListRequest) Max(max int64) *openstackIma
 	return p
 }
 
+func (p *openstackImageProvidersServiceListRequest) Search(search string) *openstackImageProvidersServiceListRequest {
+	p.search = &search
+	return p
+}
+
 func (p *openstackImageProvidersServiceListRequest) Send() (*openstackImageProvidersServiceListResponse, error) {
 	rawURL := fmt.Sprintf("%s%s", p.openstackImageProvidersService.connection.URL(), p.openstackImageProvidersService.path)
 	values := make(url.Values)
@@ -8728,6 +9307,10 @@ func (p *openstackImageProvidersServiceListRequest) Send() (*openstackImageProvi
 
 	if p.max != nil {
 		values["max"] = []string{fmt.Sprintf("%v", *p.max)}
+	}
+
+	if p.search != nil {
+		values["search"] = []string{fmt.Sprintf("%v", *p.search)}
 	}
 
 	if p.query != nil {
@@ -8769,6 +9352,17 @@ func (p *openstackImageProvidersServiceListRequest) Send() (*openstackImageProvi
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackImageProvidersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackImageProvidersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -8794,7 +9388,7 @@ func (p *openstackImageProvidersServiceListRequest) MustSend() *openstackImagePr
 
 //
 // Returns the list of providers.
-// The order of the returned list of providers isn't guaranteed.
+// The order of the returned list of providers is not guaranteed.
 //
 type openstackImageProvidersServiceListResponse struct {
 	providers *OpenStackImageProviderSlice
@@ -8816,7 +9410,7 @@ func (p *openstackImageProvidersServiceListResponse) MustProviders() *OpenStackI
 
 //
 // Returns the list of providers.
-// The order of the returned list of providers isn't guaranteed.
+// The order of the returned list of providers is not guaranteed.
 //
 func (p *openstackImageProvidersService) List() *openstackImageProvidersServiceListRequest {
 	return &openstackImageProvidersServiceListRequest{openstackImageProvidersService: p}
@@ -8935,6 +9529,17 @@ func (p *openstackImageProviderServiceGetRequest) Send() (*openstackImageProvide
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackImageProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackImageProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -9075,6 +9680,17 @@ func (p *openstackImageProviderServiceImportCertificatesRequest) Send() (*openst
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackImageProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackImageProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -9179,6 +9795,17 @@ func (p *openstackImageProviderServiceRemoveRequest) Send() (*openstackImageProv
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackImageProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackImageProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -9298,6 +9925,17 @@ func (p *openstackImageProviderServiceTestConnectivityRequest) Send() (*openstac
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackImageProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackImageProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -9426,6 +10064,17 @@ func (p *openstackImageProviderServiceUpdateRequest) Send() (*openstackImageProv
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackImageProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackImageProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -9605,6 +10254,17 @@ func (p *openstackImageServiceGetRequest) Send() (*openstackImageServiceGetRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackImageService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackImageService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -9794,6 +10454,17 @@ func (p *openstackImageServiceImportRequest) Send() (*openstackImageServiceImpor
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackImageService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackImageService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -9973,6 +10644,17 @@ func (p *openstackVolumeTypesServiceListRequest) Send() (*openstackVolumeTypesSe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeTypesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeTypesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -10139,6 +10821,17 @@ func (p *openstackSubnetServiceGetRequest) Send() (*openstackSubnetServiceGetRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackSubnetService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackSubnetService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -10264,6 +10957,17 @@ func (p *openstackSubnetServiceRemoveRequest) Send() (*openstackSubnetServiceRem
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackSubnetService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackSubnetService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -10408,6 +11112,17 @@ func (p *openstackNetworksServiceListRequest) Send() (*openstackNetworksServiceL
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackNetworksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackNetworksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -10574,6 +11289,17 @@ func (p *openstackVolumeProviderServiceGetRequest) Send() (*openstackVolumeProvi
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -10714,6 +11440,17 @@ func (p *openstackVolumeProviderServiceImportCertificatesRequest) Send() (*opens
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -10828,6 +11565,17 @@ func (p *openstackVolumeProviderServiceRemoveRequest) Send() (*openstackVolumePr
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -10947,6 +11695,17 @@ func (p *openstackVolumeProviderServiceTestConnectivityRequest) Send() (*opensta
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -11075,6 +11834,17 @@ func (p *openstackVolumeProviderServiceUpdateRequest) Send() (*openstackVolumePr
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -11278,6 +12048,17 @@ func (p *openstackImagesServiceListRequest) Send() (*openstackImagesServiceListR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackImagesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackImagesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -11449,6 +12230,17 @@ func (p *openstackVolumeAuthenticationKeysServiceAddRequest) Send() (*openstackV
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeAuthenticationKeysService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeAuthenticationKeysService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -11588,6 +12380,17 @@ func (p *openstackVolumeAuthenticationKeysServiceListRequest) Send() (*openstack
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeAuthenticationKeysService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeAuthenticationKeysService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -11680,7 +12483,7 @@ func NewOpenstackNetworkProvidersService(connection *Connection, path string) *o
 }
 
 //
-// The operation adds a new network provider to the system.
+// Adds a new network provider to the system.
 // If the `type` property is not present, a default value of `NEUTRON` will be used.
 //
 type openstackNetworkProvidersServiceAddRequest struct {
@@ -11760,6 +12563,17 @@ func (p *openstackNetworkProvidersServiceAddRequest) Send() (*openstackNetworkPr
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackNetworkProvidersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackNetworkProvidersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -11784,7 +12598,7 @@ func (p *openstackNetworkProvidersServiceAddRequest) MustSend() *openstackNetwor
 }
 
 //
-// The operation adds a new network provider to the system.
+// Adds a new network provider to the system.
 // If the `type` property is not present, a default value of `NEUTRON` will be used.
 //
 type openstackNetworkProvidersServiceAddResponse struct {
@@ -11806,7 +12620,7 @@ func (p *openstackNetworkProvidersServiceAddResponse) MustProvider() *OpenStackN
 }
 
 //
-// The operation adds a new network provider to the system.
+// Adds a new network provider to the system.
 // If the `type` property is not present, a default value of `NEUTRON` will be used.
 //
 func (p *openstackNetworkProvidersService) Add() *openstackNetworkProvidersServiceAddRequest {
@@ -11815,7 +12629,7 @@ func (p *openstackNetworkProvidersService) Add() *openstackNetworkProvidersServi
 
 //
 // Returns the list of providers.
-// The order of the returned list of providers isn't guaranteed.
+// The order of the returned list of providers is not guaranteed.
 //
 type openstackNetworkProvidersServiceListRequest struct {
 	openstackNetworkProvidersService *openstackNetworkProvidersService
@@ -11823,6 +12637,7 @@ type openstackNetworkProvidersServiceListRequest struct {
 	query                            map[string]string
 	follow                           *string
 	max                              *int64
+	search                           *string
 }
 
 func (p *openstackNetworkProvidersServiceListRequest) Header(key, value string) *openstackNetworkProvidersServiceListRequest {
@@ -11851,6 +12666,11 @@ func (p *openstackNetworkProvidersServiceListRequest) Max(max int64) *openstackN
 	return p
 }
 
+func (p *openstackNetworkProvidersServiceListRequest) Search(search string) *openstackNetworkProvidersServiceListRequest {
+	p.search = &search
+	return p
+}
+
 func (p *openstackNetworkProvidersServiceListRequest) Send() (*openstackNetworkProvidersServiceListResponse, error) {
 	rawURL := fmt.Sprintf("%s%s", p.openstackNetworkProvidersService.connection.URL(), p.openstackNetworkProvidersService.path)
 	values := make(url.Values)
@@ -11860,6 +12680,10 @@ func (p *openstackNetworkProvidersServiceListRequest) Send() (*openstackNetworkP
 
 	if p.max != nil {
 		values["max"] = []string{fmt.Sprintf("%v", *p.max)}
+	}
+
+	if p.search != nil {
+		values["search"] = []string{fmt.Sprintf("%v", *p.search)}
 	}
 
 	if p.query != nil {
@@ -11901,6 +12725,17 @@ func (p *openstackNetworkProvidersServiceListRequest) Send() (*openstackNetworkP
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackNetworkProvidersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackNetworkProvidersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -11926,7 +12761,7 @@ func (p *openstackNetworkProvidersServiceListRequest) MustSend() *openstackNetwo
 
 //
 // Returns the list of providers.
-// The order of the returned list of providers isn't guaranteed.
+// The order of the returned list of providers is not guaranteed.
 //
 type openstackNetworkProvidersServiceListResponse struct {
 	providers *OpenStackNetworkProviderSlice
@@ -11948,14 +12783,14 @@ func (p *openstackNetworkProvidersServiceListResponse) MustProviders() *OpenStac
 
 //
 // Returns the list of providers.
-// The order of the returned list of providers isn't guaranteed.
+// The order of the returned list of providers is not guaranteed.
 //
 func (p *openstackNetworkProvidersService) List() *openstackNetworkProvidersServiceListRequest {
 	return &openstackNetworkProvidersServiceListRequest{openstackNetworkProvidersService: p}
 }
 
 //
-// Reference to OpenStack network provider service.
+// Reference to the OpenStack network provider service.
 //
 func (op *openstackNetworkProvidersService) ProviderService(id string) *openstackNetworkProviderService {
 	return NewOpenstackNetworkProviderService(op.connection, fmt.Sprintf("%s/%s", op.path, id))
@@ -12068,6 +12903,17 @@ func (p *openstackNetworkServiceGetRequest) Send() (*openstackNetworkServiceGetR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -12118,8 +12964,8 @@ func (p *openstackNetworkService) Get() *openstackNetworkServiceGetRequest {
 }
 
 //
-// This operation imports an external network into oVirt.
-// The network will be added to the data center specified.
+// This operation imports an external network into {product-name}.
+// The network will be added to the specified data center.
 //
 type openstackNetworkServiceImportRequest struct {
 	openstackNetworkService *openstackNetworkService
@@ -12210,6 +13056,17 @@ func (p *openstackNetworkServiceImportRequest) Send() (*openstackNetworkServiceI
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -12226,15 +13083,15 @@ func (p *openstackNetworkServiceImportRequest) MustSend() *openstackNetworkServi
 }
 
 //
-// This operation imports an external network into oVirt.
-// The network will be added to the data center specified.
+// This operation imports an external network into {product-name}.
+// The network will be added to the specified data center.
 //
 type openstackNetworkServiceImportResponse struct {
 }
 
 //
-// This operation imports an external network into oVirt.
-// The network will be added to the data center specified.
+// This operation imports an external network into {product-name}.
+// The network will be added to the specified data center.
 //
 func (p *openstackNetworkService) Import() *openstackNetworkServiceImportRequest {
 	return &openstackNetworkServiceImportRequest{openstackNetworkService: p}
@@ -12379,6 +13236,17 @@ func (p *openstackVolumeProvidersServiceAddRequest) Send() (*openstackVolumeProv
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeProvidersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeProvidersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -12472,7 +13340,7 @@ func (p *openstackVolumeProvidersService) Add() *openstackVolumeProvidersService
 
 //
 // Retrieves the list of volume providers.
-// The order of the returned list of volume providers isn't guaranteed.
+// The order of the returned list of volume providers is not guaranteed.
 //
 type openstackVolumeProvidersServiceListRequest struct {
 	openstackVolumeProvidersService *openstackVolumeProvidersService
@@ -12480,6 +13348,7 @@ type openstackVolumeProvidersServiceListRequest struct {
 	query                           map[string]string
 	follow                          *string
 	max                             *int64
+	search                          *string
 }
 
 func (p *openstackVolumeProvidersServiceListRequest) Header(key, value string) *openstackVolumeProvidersServiceListRequest {
@@ -12508,6 +13377,11 @@ func (p *openstackVolumeProvidersServiceListRequest) Max(max int64) *openstackVo
 	return p
 }
 
+func (p *openstackVolumeProvidersServiceListRequest) Search(search string) *openstackVolumeProvidersServiceListRequest {
+	p.search = &search
+	return p
+}
+
 func (p *openstackVolumeProvidersServiceListRequest) Send() (*openstackVolumeProvidersServiceListResponse, error) {
 	rawURL := fmt.Sprintf("%s%s", p.openstackVolumeProvidersService.connection.URL(), p.openstackVolumeProvidersService.path)
 	values := make(url.Values)
@@ -12517,6 +13391,10 @@ func (p *openstackVolumeProvidersServiceListRequest) Send() (*openstackVolumePro
 
 	if p.max != nil {
 		values["max"] = []string{fmt.Sprintf("%v", *p.max)}
+	}
+
+	if p.search != nil {
+		values["search"] = []string{fmt.Sprintf("%v", *p.search)}
 	}
 
 	if p.query != nil {
@@ -12558,6 +13436,17 @@ func (p *openstackVolumeProvidersServiceListRequest) Send() (*openstackVolumePro
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackVolumeProvidersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackVolumeProvidersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -12583,7 +13472,7 @@ func (p *openstackVolumeProvidersServiceListRequest) MustSend() *openstackVolume
 
 //
 // Retrieves the list of volume providers.
-// The order of the returned list of volume providers isn't guaranteed.
+// The order of the returned list of volume providers is not guaranteed.
 //
 type openstackVolumeProvidersServiceListResponse struct {
 	providers *OpenStackVolumeProviderSlice
@@ -12605,7 +13494,7 @@ func (p *openstackVolumeProvidersServiceListResponse) MustProviders() *OpenStack
 
 //
 // Retrieves the list of volume providers.
-// The order of the returned list of volume providers isn't guaranteed.
+// The order of the returned list of volume providers is not guaranteed.
 //
 func (p *openstackVolumeProvidersService) List() *openstackVolumeProvidersServiceListRequest {
 	return &openstackVolumeProvidersServiceListRequest{openstackVolumeProvidersService: p}
@@ -12731,6 +13620,17 @@ func (p *openstackNetworkProviderServiceGetRequest) Send() (*openstackNetworkPro
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackNetworkProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackNetworkProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -12883,6 +13783,17 @@ func (p *openstackNetworkProviderServiceImportCertificatesRequest) Send() (*open
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackNetworkProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackNetworkProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -12993,6 +13904,17 @@ func (p *openstackNetworkProviderServiceRemoveRequest) Send() (*openstackNetwork
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackNetworkProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackNetworkProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -13124,6 +14046,17 @@ func (p *openstackNetworkProviderServiceTestConnectivityRequest) Send() (*openst
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackNetworkProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackNetworkProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -13269,6 +14202,17 @@ func (p *openstackNetworkProviderServiceUpdateRequest) Send() (*openstackNetwork
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.openstackNetworkProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.openstackNetworkProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -13483,6 +14427,17 @@ func (p *assignedCpuProfileServiceGetRequest) Send() (*assignedCpuProfileService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedCpuProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedCpuProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -13608,6 +14563,17 @@ func (p *assignedCpuProfileServiceRemoveRequest) Send() (*assignedCpuProfileServ
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedCpuProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedCpuProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -13762,6 +14728,17 @@ func (p *storageServerConnectionsServiceAddRequest) Send() (*storageServerConnec
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -13850,6 +14827,144 @@ func (p *storageServerConnectionsService) Add() *storageServerConnectionsService
 }
 
 //
+// Add a Glusterfs storage connection to the system.
+//
+type storageServerConnectionsServiceAddGlusterfsRequest struct {
+	storageServerConnectionsService *storageServerConnectionsService
+	header                          map[string]string
+	query                           map[string]string
+	connection                      *StorageConnection
+}
+
+func (p *storageServerConnectionsServiceAddGlusterfsRequest) Header(key, value string) *storageServerConnectionsServiceAddGlusterfsRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *storageServerConnectionsServiceAddGlusterfsRequest) Query(key, value string) *storageServerConnectionsServiceAddGlusterfsRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *storageServerConnectionsServiceAddGlusterfsRequest) Connection(connection *StorageConnection) *storageServerConnectionsServiceAddGlusterfsRequest {
+	p.connection = connection
+	return p
+}
+
+func (p *storageServerConnectionsServiceAddGlusterfsRequest) Send() (*storageServerConnectionsServiceAddGlusterfsResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/glusterfs", p.storageServerConnectionsService.connection.URL(), p.storageServerConnectionsService.path)
+	actionBuilder := NewActionBuilder()
+	actionBuilder.Connection(p.connection)
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.storageServerConnectionsService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.storageServerConnectionsService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.storageServerConnectionsService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.storageServerConnectionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	action, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	result := action.MustConnection()
+	return &storageServerConnectionsServiceAddGlusterfsResponse{connection: result}, nil
+}
+
+func (p *storageServerConnectionsServiceAddGlusterfsRequest) MustSend() *storageServerConnectionsServiceAddGlusterfsResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Add a Glusterfs storage connection to the system.
+//
+type storageServerConnectionsServiceAddGlusterfsResponse struct {
+	connection *StorageConnection
+}
+
+func (p *storageServerConnectionsServiceAddGlusterfsResponse) Connection() (*StorageConnection, bool) {
+	if p.connection != nil {
+		return p.connection, true
+	}
+	return nil, false
+}
+
+func (p *storageServerConnectionsServiceAddGlusterfsResponse) MustConnection() *StorageConnection {
+	if p.connection == nil {
+		panic("connection in response does not exist")
+	}
+	return p.connection
+}
+
+//
+// Add a Glusterfs storage connection to the system.
+//
+func (p *storageServerConnectionsService) AddGlusterfs() *storageServerConnectionsServiceAddGlusterfsRequest {
+	return &storageServerConnectionsServiceAddGlusterfsRequest{storageServerConnectionsService: p}
+}
+
+//
 // Add a iSCSI storage connection to the system.
 //
 type storageServerConnectionsServiceAddIscsiRequest struct {
@@ -13932,6 +15047,17 @@ func (p *storageServerConnectionsServiceAddIscsiRequest) Send() (*storageServerC
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -14064,6 +15190,17 @@ func (p *storageServerConnectionsServiceListRequest) Send() (*storageServerConne
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -14200,6 +15337,17 @@ func (p *storageServerConnectionsServiceAddLocalRequest) Send() (*storageServerC
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -14327,6 +15475,17 @@ func (p *storageServerConnectionsServiceAddNfsRequest) Send() (*storageServerCon
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -14454,6 +15613,17 @@ func (p *storageServerConnectionsServiceAddVfsRequest) Send() (*storageServerCon
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -14619,6 +15789,17 @@ func (p *copyableServiceCopyRequest) Send() (*copyableServiceCopyResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.copyableService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.copyableService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -14781,6 +15962,17 @@ func (p *vmSessionsServiceListRequest) Send() (*vmSessionsServiceListResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmSessionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmSessionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -14996,6 +16188,17 @@ func (p *vmDiskServiceActivateRequest) Send() (*vmDiskServiceActivateResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -15106,6 +16309,17 @@ func (p *vmDiskServiceDeactivateRequest) Send() (*vmDiskServiceDeactivateRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -15225,6 +16439,17 @@ func (p *vmDiskServiceExportRequest) Send() (*vmDiskServiceExportResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -15327,6 +16552,17 @@ func (p *vmDiskServiceGetRequest) Send() (*vmDiskServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -15469,6 +16705,17 @@ func (p *vmDiskServiceMoveRequest) Send() (*vmDiskServiceMoveResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -15493,6 +16740,139 @@ type vmDiskServiceMoveResponse struct {
 //
 func (p *vmDiskService) Move() *vmDiskServiceMoveRequest {
 	return &vmDiskServiceMoveRequest{vmDiskService: p}
+}
+
+//
+// Reduces the size of the disk image.
+// Invokes _reduce_ on the logical volume (i.e. this is only applicable for block storage domains).
+// This is applicable for floating disks and disks attached to non-running virtual machines.
+// There is no need to specify the size as the optimal size is calculated automatically.
+//
+type vmDiskServiceReduceRequest struct {
+	vmDiskService *vmDiskService
+	header        map[string]string
+	query         map[string]string
+	async         *bool
+}
+
+func (p *vmDiskServiceReduceRequest) Header(key, value string) *vmDiskServiceReduceRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *vmDiskServiceReduceRequest) Query(key, value string) *vmDiskServiceReduceRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *vmDiskServiceReduceRequest) Async(async bool) *vmDiskServiceReduceRequest {
+	p.async = &async
+	return p
+}
+
+func (p *vmDiskServiceReduceRequest) Send() (*vmDiskServiceReduceResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/reduce", p.vmDiskService.connection.URL(), p.vmDiskService.path)
+	actionBuilder := NewActionBuilder()
+	if p.async != nil {
+		actionBuilder.Async(*p.async)
+	}
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.vmDiskService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.vmDiskService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.vmDiskService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.vmDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	_, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	return new(vmDiskServiceReduceResponse), nil
+}
+
+func (p *vmDiskServiceReduceRequest) MustSend() *vmDiskServiceReduceResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Reduces the size of the disk image.
+// Invokes _reduce_ on the logical volume (i.e. this is only applicable for block storage domains).
+// This is applicable for floating disks and disks attached to non-running virtual machines.
+// There is no need to specify the size as the optimal size is calculated automatically.
+//
+type vmDiskServiceReduceResponse struct {
+}
+
+//
+// Reduces the size of the disk image.
+// Invokes _reduce_ on the logical volume (i.e. this is only applicable for block storage domains).
+// This is applicable for floating disks and disks attached to non-running virtual machines.
+// There is no need to specify the size as the optimal size is calculated automatically.
+//
+func (p *vmDiskService) Reduce() *vmDiskServiceReduceRequest {
+	return &vmDiskServiceReduceRequest{vmDiskService: p}
 }
 
 //
@@ -15575,6 +16955,17 @@ func (p *vmDiskServiceRemoveRequest) Send() (*vmDiskServiceRemoveResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -15701,6 +17092,17 @@ func (p *vmDiskServiceUpdateRequest) Send() (*vmDiskServiceUpdateResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -15895,6 +17297,17 @@ func (p *hostDeviceServiceGetRequest) Send() (*hostDeviceServiceGetResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostDeviceService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostDeviceService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -16081,6 +17494,17 @@ func (p *assignedVnicProfileServiceGetRequest) Send() (*assignedVnicProfileServi
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedVnicProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedVnicProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -16206,6 +17630,17 @@ func (p *assignedVnicProfileServiceRemoveRequest) Send() (*assignedVnicProfileSe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedVnicProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedVnicProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -16350,6 +17785,17 @@ func (p *cpuProfileServiceGetRequest) Send() (*cpuProfileServiceGetResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.cpuProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.cpuProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -16475,6 +17921,17 @@ func (p *cpuProfileServiceRemoveRequest) Send() (*cpuProfileServiceRemoveRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.cpuProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.cpuProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -16594,6 +18051,17 @@ func (p *cpuProfileServiceUpdateRequest) Send() (*cpuProfileServiceUpdateRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.cpuProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.cpuProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -16762,6 +18230,17 @@ func (p *dataCenterNetworkServiceGetRequest) Send() (*dataCenterNetworkServiceGe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.dataCenterNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.dataCenterNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -16880,6 +18359,17 @@ func (p *dataCenterNetworkServiceRemoveRequest) Send() (*dataCenterNetworkServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.dataCenterNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.dataCenterNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -16991,6 +18481,17 @@ func (p *dataCenterNetworkServiceUpdateRequest) Send() (*dataCenterNetworkServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.dataCenterNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.dataCenterNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -17198,6 +18699,17 @@ func (p *networkFiltersServiceListRequest) Send() (*networkFiltersServiceListRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkFiltersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkFiltersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -17374,6 +18886,17 @@ func (p *schedulingPolicyUnitServiceGetRequest) Send() (*schedulingPolicyUnitSer
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.schedulingPolicyUnitService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.schedulingPolicyUnitService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -17499,6 +19022,17 @@ func (p *schedulingPolicyUnitServiceRemoveRequest) Send() (*schedulingPolicyUnit
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.schedulingPolicyUnitService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.schedulingPolicyUnitService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -17633,6 +19167,17 @@ func (p *externalNetworkProviderConfigurationServiceGetRequest) Send() (*externa
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalNetworkProviderConfigurationService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalNetworkProviderConfigurationService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -17733,6 +19278,7 @@ func NewVnicProfilesService(connection *Connection, path string) *vnicProfilesSe
 // Please note that there is a default network filter to each VNIC profile.
 // For more details of how the default network filter is calculated please refer to
 // the documentation in <<services/network_filters,NetworkFilters>>.
+// NOTE: The automatically created vNIC profile for the external network will be without network filter.
 // The output of creating a new VNIC profile depends in the  body  arguments that were given.
 // In case no network filter was given, the default network filter will be configured. For example:
 // [source,xml]
@@ -17844,6 +19390,17 @@ func (p *vnicProfilesServiceAddRequest) Send() (*vnicProfilesServiceAddResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vnicProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vnicProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -17888,6 +19445,7 @@ func (p *vnicProfilesServiceAddRequest) MustSend() *vnicProfilesServiceAddRespon
 // Please note that there is a default network filter to each VNIC profile.
 // For more details of how the default network filter is calculated please refer to
 // the documentation in <<services/network_filters,NetworkFilters>>.
+// NOTE: The automatically created vNIC profile for the external network will be without network filter.
 // The output of creating a new VNIC profile depends in the  body  arguments that were given.
 // In case no network filter was given, the default network filter will be configured. For example:
 // [source,xml]
@@ -17961,6 +19519,7 @@ func (p *vnicProfilesServiceAddResponse) MustProfile() *VnicProfile {
 // Please note that there is a default network filter to each VNIC profile.
 // For more details of how the default network filter is calculated please refer to
 // the documentation in <<services/network_filters,NetworkFilters>>.
+// NOTE: The automatically created vNIC profile for the external network will be without network filter.
 // The output of creating a new VNIC profile depends in the  body  arguments that were given.
 // In case no network filter was given, the default network filter will be configured. For example:
 // [source,xml]
@@ -18087,6 +19646,17 @@ func (p *vnicProfilesServiceListRequest) Send() (*vnicProfilesServiceListRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vnicProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vnicProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -18259,6 +19829,17 @@ func (p *assignedAffinityLabelsServiceAddRequest) Send() (*assignedAffinityLabel
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedAffinityLabelsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedAffinityLabelsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -18388,6 +19969,17 @@ func (p *assignedAffinityLabelsServiceListRequest) Send() (*assignedAffinityLabe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedAffinityLabelsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedAffinityLabelsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -18556,6 +20148,17 @@ func (p *iscsiBondServiceGetRequest) Send() (*iscsiBondServiceGetResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.iscsiBondService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.iscsiBondService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -18687,6 +20290,17 @@ func (p *iscsiBondServiceRemoveRequest) Send() (*iscsiBondServiceRemoveResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.iscsiBondService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.iscsiBondService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -18832,6 +20446,17 @@ func (p *iscsiBondServiceUpdateRequest) Send() (*iscsiBondServiceUpdateResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.iscsiBondService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.iscsiBondService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -19048,6 +20673,17 @@ func (p *storageDomainContentDiskServiceGetRequest) Send() (*storageDomainConten
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainContentDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainContentDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -19200,6 +20836,17 @@ func (p *networkAttachmentServiceGetRequest) Send() (*networkAttachmentServiceGe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkAttachmentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkAttachmentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -19325,6 +20972,17 @@ func (p *networkAttachmentServiceRemoveRequest) Send() (*networkAttachmentServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkAttachmentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkAttachmentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -19444,6 +21102,17 @@ func (p *networkAttachmentServiceUpdateRequest) Send() (*networkAttachmentServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkAttachmentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkAttachmentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -19598,6 +21267,17 @@ func (p *vmReportedDeviceServiceGetRequest) Send() (*vmReportedDeviceServiceGetR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmReportedDeviceService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmReportedDeviceService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -19750,6 +21430,17 @@ func (p *snapshotDiskServiceGetRequest) Send() (*snapshotDiskServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -19949,6 +21640,17 @@ func (p *storageDomainVmsServiceListRequest) Send() (*storageDomainVmsServiceLis
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainVmsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainVmsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -20197,6 +21899,17 @@ func (p *instanceTypesServiceAddRequest) Send() (*instanceTypesServiceAddRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -20512,6 +22225,17 @@ func (p *instanceTypesServiceListRequest) Send() (*instanceTypesServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -20731,6 +22455,17 @@ func (p *domainUsersServiceListRequest) Send() (*domainUsersServiceListResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.domainUsersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.domainUsersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -20938,6 +22673,17 @@ func (p *domainGroupServiceGetRequest) Send() (*domainGroupServiceGetResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.domainGroupService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.domainGroupService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -21122,6 +22868,17 @@ func (p *domainGroupsServiceListRequest) Send() (*domainGroupsServiceListRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.domainGroupsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.domainGroupsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -21310,6 +23067,17 @@ func (p *groupServiceGetRequest) Send() (*groupServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.groupService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.groupService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -21480,6 +23248,17 @@ func (p *groupServiceRemoveRequest) Send() (*groupServiceRemoveResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.groupService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.groupService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -21664,6 +23443,17 @@ func (p *sshPublicKeysServiceAddRequest) Send() (*sshPublicKeysServiceAddRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.sshPublicKeysService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.sshPublicKeysService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -21834,6 +23624,17 @@ func (p *sshPublicKeysServiceListRequest) Send() (*sshPublicKeysServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.sshPublicKeysService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.sshPublicKeysService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -22096,6 +23897,17 @@ func (p *userServiceGetRequest) Send() (*userServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.userService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.userService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -22278,6 +24090,17 @@ func (p *userServiceRemoveRequest) Send() (*userServiceRemoveResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.userService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.userService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -22319,6 +24142,12 @@ func (p *userService) Remove() *userServiceRemoveRequest {
 
 //
 //
+func (op *userService) GroupsService() *domainUserGroupsService {
+	return NewDomainUserGroupsService(op.connection, fmt.Sprintf("%s/groups", op.path))
+}
+
+//
+//
 func (op *userService) PermissionsService() *assignedPermissionsService {
 	return NewAssignedPermissionsService(op.connection, fmt.Sprintf("%s/permissions", op.path))
 }
@@ -22347,6 +24176,12 @@ func (op *userService) TagsService() *assignedTagsService {
 func (op *userService) Service(path string) (Service, error) {
 	if path == "" {
 		return op, nil
+	}
+	if path == "groups" {
+		return op.GroupsService(), nil
+	}
+	if strings.HasPrefix(path, "groups/") {
+		return op.GroupsService().Service(path[7:])
 	}
 	if path == "permissions" {
 		return op.PermissionsService(), nil
@@ -22489,6 +24324,17 @@ func (p *groupsServiceAddRequest) Send() (*groupsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.groupsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.groupsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -22702,6 +24548,17 @@ func (p *groupsServiceListRequest) Send() (*groupsServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.groupsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.groupsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -22943,6 +24800,17 @@ func (p *domainsServiceListRequest) Send() (*domainsServiceListResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.domainsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.domainsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -23056,6 +24924,173 @@ func (op *domainsService) String() string {
 }
 
 //
+// A service that shows a user's group membership in the AAA extension.
+//
+type domainUserGroupsService struct {
+	baseService
+}
+
+func NewDomainUserGroupsService(connection *Connection, path string) *domainUserGroupsService {
+	var result domainUserGroupsService
+	result.connection = connection
+	result.path = path
+	return &result
+}
+
+//
+// Returns the list of groups that the user is a member of.
+//
+type domainUserGroupsServiceListRequest struct {
+	domainUserGroupsService *domainUserGroupsService
+	header                  map[string]string
+	query                   map[string]string
+	follow                  *string
+}
+
+func (p *domainUserGroupsServiceListRequest) Header(key, value string) *domainUserGroupsServiceListRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *domainUserGroupsServiceListRequest) Query(key, value string) *domainUserGroupsServiceListRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *domainUserGroupsServiceListRequest) Follow(follow string) *domainUserGroupsServiceListRequest {
+	p.follow = &follow
+	return p
+}
+
+func (p *domainUserGroupsServiceListRequest) Send() (*domainUserGroupsServiceListResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.domainUserGroupsService.connection.URL(), p.domainUserGroupsService.path)
+	values := make(url.Values)
+	if p.follow != nil {
+		values["follow"] = []string{fmt.Sprintf("%v", *p.follow)}
+	}
+
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.domainUserGroupsService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.domainUserGroupsService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.domainUserGroupsService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.domainUserGroupsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.domainUserGroupsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200}) {
+		return nil, CheckFault(resp)
+	}
+	respBodyBytes, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	reader := NewXMLReader(respBodyBytes)
+	result, err := XMLGroupReadMany(reader, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &domainUserGroupsServiceListResponse{groups: result}, nil
+}
+
+func (p *domainUserGroupsServiceListRequest) MustSend() *domainUserGroupsServiceListResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Returns the list of groups that the user is a member of.
+//
+type domainUserGroupsServiceListResponse struct {
+	groups *GroupSlice
+}
+
+func (p *domainUserGroupsServiceListResponse) Groups() (*GroupSlice, bool) {
+	if p.groups != nil {
+		return p.groups, true
+	}
+	return nil, false
+}
+
+func (p *domainUserGroupsServiceListResponse) MustGroups() *GroupSlice {
+	if p.groups == nil {
+		panic("groups in response does not exist")
+	}
+	return p.groups
+}
+
+//
+// Returns the list of groups that the user is a member of.
+//
+func (p *domainUserGroupsService) List() *domainUserGroupsServiceListRequest {
+	return &domainUserGroupsServiceListRequest{domainUserGroupsService: p}
+}
+
+//
+// Service locator method, returns individual service on which the URI is dispatched.
+//
+func (op *domainUserGroupsService) Service(path string) (Service, error) {
+	if path == "" {
+		return op, nil
+	}
+	return nil, fmt.Errorf("The path <%s> doesn't correspond to any service", path)
+}
+
+func (op *domainUserGroupsService) String() string {
+	return fmt.Sprintf("domainUserGroupsService:%s", op.path)
+}
+
+//
 //
 type sshPublicKeyService struct {
 	baseService
@@ -23144,6 +25179,17 @@ func (p *sshPublicKeyServiceGetRequest) Send() (*sshPublicKeyServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.sshPublicKeyService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.sshPublicKeyService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -23269,6 +25315,17 @@ func (p *sshPublicKeyServiceRemoveRequest) Send() (*sshPublicKeyServiceRemoveRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.sshPublicKeyService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.sshPublicKeyService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -23387,6 +25444,17 @@ func (p *sshPublicKeyServiceUpdateRequest) Send() (*sshPublicKeyServiceUpdateRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.sshPublicKeyService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.sshPublicKeyService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -23575,6 +25643,17 @@ func (p *usersServiceAddRequest) Send() (*usersServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.usersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.usersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -23820,6 +25899,17 @@ func (p *usersServiceListRequest) Send() (*usersServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.usersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.usersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -24054,6 +26144,17 @@ func (p *domainUserServiceGetRequest) Send() (*domainUserServiceGetResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.domainUserService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.domainUserService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -24261,6 +26362,17 @@ func (p *domainServiceGetRequest) Send() (*domainServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.domainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.domainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -24473,6 +26585,17 @@ func (p *affinityLabelServiceGetRequest) Send() (*affinityLabelServiceGetRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -24592,6 +26715,17 @@ func (p *affinityLabelServiceRemoveRequest) Send() (*affinityLabelServiceRemoveR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -24706,6 +26840,17 @@ func (p *affinityLabelServiceUpdateRequest) Send() (*affinityLabelServiceUpdateR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -24889,6 +27034,17 @@ func (p *hostNicServiceGetRequest) Send() (*hostNicServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -25034,6 +27190,17 @@ func (p *hostNicServiceUpdateVirtualFunctionsConfigurationRequest) Send() (*host
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -25274,6 +27441,17 @@ func (p *attachedStorageDomainDiskServiceCopyRequest) Send() (*attachedStorageDo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -25394,6 +27572,17 @@ func (p *attachedStorageDomainDiskServiceExportRequest) Send() (*attachedStorage
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -25505,6 +27694,17 @@ func (p *attachedStorageDomainDiskServiceGetRequest) Send() (*attachedStorageDom
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -25660,6 +27860,17 @@ func (p *attachedStorageDomainDiskServiceMoveRequest) Send() (*attachedStorageDo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -25770,6 +27981,17 @@ func (p *attachedStorageDomainDiskServiceRegisterRequest) Send() (*attachedStora
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -25868,6 +28090,17 @@ func (p *attachedStorageDomainDiskServiceRemoveRequest) Send() (*attachedStorage
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -25984,6 +28217,17 @@ func (p *attachedStorageDomainDiskServiceSparsifyRequest) Send() (*attachedStora
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -26101,6 +28345,17 @@ func (p *attachedStorageDomainDiskServiceUpdateRequest) Send() (*attachedStorage
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -26287,6 +28542,17 @@ func (p *instanceTypeNicServiceGetRequest) Send() (*instanceTypeNicServiceGetRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -26415,6 +28681,17 @@ func (p *instanceTypeNicServiceRemoveRequest) Send() (*instanceTypeNicServiceRem
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -26536,6 +28813,17 @@ func (p *instanceTypeNicServiceUpdateRequest) Send() (*instanceTypeNicServiceUpd
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -26696,6 +28984,17 @@ func (p *affinityLabelsServiceAddRequest) Send() (*affinityLabelsServiceAddRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -26837,6 +29136,17 @@ func (p *affinityLabelsServiceListRequest) Send() (*affinityLabelsServiceListRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -27004,6 +29314,17 @@ func (p *templateWatchdogServiceGetRequest) Send() (*templateWatchdogServiceGetR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateWatchdogService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateWatchdogService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -27129,6 +29450,17 @@ func (p *templateWatchdogServiceRemoveRequest) Send() (*templateWatchdogServiceR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateWatchdogService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateWatchdogService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -27248,6 +29580,17 @@ func (p *templateWatchdogServiceUpdateRequest) Send() (*templateWatchdogServiceU
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateWatchdogService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateWatchdogService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -27560,6 +29903,17 @@ func (p *vmsServiceAddRequest) Send() (*vmsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -27980,6 +30334,17 @@ func (p *vmsServiceAddFromConfigurationRequest) Send() (*vmsServiceAddFromConfig
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -28125,6 +30490,17 @@ func (p *vmsServiceAddFromScratchRequest) Send() (*vmsServiceAddFromScratchRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -28270,6 +30646,17 @@ func (p *vmsServiceAddFromSnapshotRequest) Send() (*vmsServiceAddFromSnapshotRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -28443,6 +30830,17 @@ func (p *vmsServiceListRequest) Send() (*vmsServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -28669,6 +31067,17 @@ func (p *filesServiceListRequest) Send() (*filesServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.filesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.filesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -28883,6 +31292,17 @@ func (p *networkServiceGetRequest) Send() (*networkServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -28993,6 +31413,11 @@ func (p *networkService) Get() *networkServiceGetRequest {
 // ----
 // DELETE /ovirt-engine/api/datacenters/123/networks/456
 // ----
+// NOTE: To remove an external logical network, the network has to be removed directly from its provider by
+// https://developer.openstack.org/api-ref/network[OpenStack Networking API].
+// The entity representing the external network inside {product-name} is removed automatically,
+// if <<types/open_stack_network_provider/attributes/auto_sync,`auto_sync`>> is enabled for the provider,
+// otherwise the entity has to be removed using this method.
 //
 type networkServiceRemoveRequest struct {
 	networkService *networkService
@@ -29068,6 +31493,17 @@ func (p *networkServiceRemoveRequest) Send() (*networkServiceRemoveResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -29101,6 +31537,11 @@ func (p *networkServiceRemoveRequest) MustSend() *networkServiceRemoveResponse {
 // ----
 // DELETE /ovirt-engine/api/datacenters/123/networks/456
 // ----
+// NOTE: To remove an external logical network, the network has to be removed directly from its provider by
+// https://developer.openstack.org/api-ref/network[OpenStack Networking API].
+// The entity representing the external network inside {product-name} is removed automatically,
+// if <<types/open_stack_network_provider/attributes/auto_sync,`auto_sync`>> is enabled for the provider,
+// otherwise the entity has to be removed using this method.
 //
 type networkServiceRemoveResponse struct {
 }
@@ -29120,6 +31561,11 @@ type networkServiceRemoveResponse struct {
 // ----
 // DELETE /ovirt-engine/api/datacenters/123/networks/456
 // ----
+// NOTE: To remove an external logical network, the network has to be removed directly from its provider by
+// https://developer.openstack.org/api-ref/network[OpenStack Networking API].
+// The entity representing the external network inside {product-name} is removed automatically,
+// if <<types/open_stack_network_provider/attributes/auto_sync,`auto_sync`>> is enabled for the provider,
+// otherwise the entity has to be removed using this method.
 //
 func (p *networkService) Remove() *networkServiceRemoveRequest {
 	return &networkServiceRemoveRequest{networkService: p}
@@ -29242,6 +31688,17 @@ func (p *networkServiceUpdateRequest) Send() (*networkServiceUpdateResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -29513,6 +31970,17 @@ func (p *iscsiBondsServiceAddRequest) Send() (*iscsiBondsServiceAddResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.iscsiBondsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.iscsiBondsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -29692,6 +32160,17 @@ func (p *iscsiBondsServiceListRequest) Send() (*iscsiBondsServiceListResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.iscsiBondsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.iscsiBondsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -29871,6 +32350,17 @@ func (p *hostDevicesServiceListRequest) Send() (*hostDevicesServiceListResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostDevicesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostDevicesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -30050,6 +32540,17 @@ func (p *vmReportedDevicesServiceListRequest) Send() (*vmReportedDevicesServiceL
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmReportedDevicesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmReportedDevicesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -30243,6 +32744,17 @@ func (p *vmHostDeviceServiceGetRequest) Send() (*vmHostDeviceServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmHostDeviceService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmHostDeviceService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -30429,6 +32941,17 @@ func (p *vmHostDeviceServiceRemoveRequest) Send() (*vmHostDeviceServiceRemoveRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmHostDeviceService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmHostDeviceService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -30584,6 +33107,17 @@ func (p *filtersServiceAddRequest) Send() (*filtersServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.filtersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.filtersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -30733,6 +33267,17 @@ func (p *filtersServiceListRequest) Send() (*filtersServiceListResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.filtersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.filtersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -30929,6 +33474,17 @@ func (p *quotaStorageLimitsServiceAddRequest) Send() (*quotaStorageLimitsService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaStorageLimitsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaStorageLimitsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -31118,6 +33674,17 @@ func (p *quotaStorageLimitsServiceListRequest) Send() (*quotaStorageLimitsServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaStorageLimitsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaStorageLimitsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -31294,6 +33861,17 @@ func (p *schedulingPolicyServiceGetRequest) Send() (*schedulingPolicyServiceGetR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.schedulingPolicyService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.schedulingPolicyService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -31419,6 +33997,17 @@ func (p *schedulingPolicyServiceRemoveRequest) Send() (*schedulingPolicyServiceR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.schedulingPolicyService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.schedulingPolicyService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -31538,6 +34127,17 @@ func (p *schedulingPolicyServiceUpdateRequest) Send() (*schedulingPolicyServiceU
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.schedulingPolicyService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.schedulingPolicyService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -31738,6 +34338,17 @@ func (p *hostServiceActivateRequest) Send() (*hostServiceActivateResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -31866,6 +34477,17 @@ func (p *hostServiceApproveRequest) Send() (*hostServiceApproveResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -31996,6 +34618,17 @@ func (p *hostServiceCommitNetConfigRequest) Send() (*hostServiceCommitNetConfigR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -32157,6 +34790,17 @@ func (p *hostServiceDeactivateRequest) Send() (*hostServiceDeactivateResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -32271,6 +34915,17 @@ func (p *hostServiceEnrollCertificateRequest) Send() (*hostServiceEnrollCertific
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -32417,6 +35072,17 @@ func (p *hostServiceFenceRequest) Send() (*hostServiceFenceResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -32599,6 +35265,17 @@ func (p *hostServiceForceSelectSpmRequest) Send() (*hostServiceForceSelectSpmRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -32746,6 +35423,17 @@ func (p *hostServiceGetRequest) Send() (*hostServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -32982,6 +35670,17 @@ func (p *hostServiceInstallRequest) Send() (*hostServiceInstallResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -33213,6 +35912,17 @@ func (p *hostServiceIscsiDiscoverRequest) Send() (*hostServiceIscsiDiscoverRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -33418,6 +36128,17 @@ func (p *hostServiceIscsiLoginRequest) Send() (*hostServiceIscsiLoginResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -33531,6 +36252,17 @@ func (p *hostServiceRefreshRequest) Send() (*hostServiceRefreshResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -33650,6 +36382,17 @@ func (p *hostServiceRemoveRequest) Send() (*hostServiceRemoveResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -34067,6 +36810,17 @@ func (p *hostServiceSetupNetworksRequest) Send() (*hostServiceSetupNetworksRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -34489,6 +37243,17 @@ func (p *hostServiceSyncAllNetworksRequest) Send() (*hostServiceSyncAllNetworksR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -34628,6 +37393,17 @@ func (p *hostServiceUnregisteredStorageDomainsDiscoverRequest) Send() (*hostServ
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -34778,6 +37554,17 @@ func (p *hostServiceUpdateRequest) Send() (*hostServiceUpdateResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -34960,6 +37747,17 @@ func (p *hostServiceUpgradeRequest) Send() (*hostServiceUpgradeResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -35067,6 +37865,17 @@ func (p *hostServiceUpgradeCheckRequest) Send() (*hostServiceUpgradeCheckRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -35201,6 +38010,17 @@ func (p *hostServiceApproveUsingRootPasswordRequest) Send() (*hostServiceApprove
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -35367,6 +38187,17 @@ func (p *hostServiceInstallUsingRootPasswordRequest) Send() (*hostServiceInstall
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -35489,6 +38320,17 @@ func (p *hostServiceUpdateUsingRootPasswordRequest) Send() (*hostServiceUpdateUs
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -35633,6 +38475,17 @@ func (p *hostServiceApproveUsingSshRequest) Send() (*hostServiceApproveUsingSshR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -35799,6 +38652,17 @@ func (p *hostServiceInstallUsingSshRequest) Send() (*hostServiceInstallUsingSshR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -35921,6 +38785,17 @@ func (p *hostServiceUpdateUsingSshRequest) Send() (*hostServiceUpdateUsingSshRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -36353,6 +39228,17 @@ func (p *clusterServiceGetRequest) Send() (*clusterServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -36635,6 +39521,17 @@ func (p *clusterServiceRemoveRequest) Send() (*clusterServiceRemoveResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -36758,6 +39655,17 @@ func (p *clusterServiceResetEmulatedMachineRequest) Send() (*clusterServiceReset
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -36782,6 +39690,157 @@ type clusterServiceResetEmulatedMachineResponse struct {
 //
 func (p *clusterService) ResetEmulatedMachine() *clusterServiceResetEmulatedMachineRequest {
 	return &clusterServiceResetEmulatedMachineRequest{clusterService: p}
+}
+
+//
+// Synchronizes all networks on the cluster.
+// [source]
+// ----
+// POST /ovirt-engine/api/clusters/123/syncallnetworks
+// ----
+// With a request body like this:
+// [source,xml]
+// ----
+// <action/>
+// ----
+//
+type clusterServiceSyncAllNetworksRequest struct {
+	clusterService *clusterService
+	header         map[string]string
+	query          map[string]string
+	async          *bool
+}
+
+func (p *clusterServiceSyncAllNetworksRequest) Header(key, value string) *clusterServiceSyncAllNetworksRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *clusterServiceSyncAllNetworksRequest) Query(key, value string) *clusterServiceSyncAllNetworksRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *clusterServiceSyncAllNetworksRequest) Async(async bool) *clusterServiceSyncAllNetworksRequest {
+	p.async = &async
+	return p
+}
+
+func (p *clusterServiceSyncAllNetworksRequest) Send() (*clusterServiceSyncAllNetworksResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/syncallnetworks", p.clusterService.connection.URL(), p.clusterService.path)
+	actionBuilder := NewActionBuilder()
+	if p.async != nil {
+		actionBuilder.Async(*p.async)
+	}
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.clusterService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.clusterService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.clusterService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.clusterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	_, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	return new(clusterServiceSyncAllNetworksResponse), nil
+}
+
+func (p *clusterServiceSyncAllNetworksRequest) MustSend() *clusterServiceSyncAllNetworksResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Synchronizes all networks on the cluster.
+// [source]
+// ----
+// POST /ovirt-engine/api/clusters/123/syncallnetworks
+// ----
+// With a request body like this:
+// [source,xml]
+// ----
+// <action/>
+// ----
+//
+type clusterServiceSyncAllNetworksResponse struct {
+}
+
+//
+// Synchronizes all networks on the cluster.
+// [source]
+// ----
+// POST /ovirt-engine/api/clusters/123/syncallnetworks
+// ----
+// With a request body like this:
+// [source,xml]
+// ----
+// <action/>
+// ----
+//
+func (p *clusterService) SyncAllNetworks() *clusterServiceSyncAllNetworksRequest {
+	return &clusterServiceSyncAllNetworksRequest{clusterService: p}
 }
 
 //
@@ -36889,6 +39948,17 @@ func (p *clusterServiceUpdateRequest) Send() (*clusterServiceUpdateResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -37212,6 +40282,17 @@ func (p *vmHostDevicesServiceAddRequest) Send() (*vmHostDevicesServiceAddRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmHostDevicesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmHostDevicesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -37385,6 +40466,17 @@ func (p *vmHostDevicesServiceListRequest) Send() (*vmHostDevicesServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmHostDevicesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmHostDevicesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -37552,6 +40644,17 @@ func (p *fileServiceGetRequest) Send() (*fileServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.fileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.fileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -37704,6 +40807,17 @@ func (p *assignedDiskProfileServiceGetRequest) Send() (*assignedDiskProfileServi
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedDiskProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedDiskProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -37829,6 +40943,17 @@ func (p *assignedDiskProfileServiceRemoveRequest) Send() (*assignedDiskProfileSe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedDiskProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedDiskProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -37965,6 +41090,17 @@ func (p *diskProfilesServiceAddRequest) Send() (*diskProfilesServiceAddResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -38104,6 +41240,17 @@ func (p *diskProfilesServiceListRequest) Send() (*diskProfilesServiceListRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -38322,6 +41469,17 @@ func (p *operatingSystemsServiceListRequest) Send() (*operatingSystemsServiceLis
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.operatingSystemsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.operatingSystemsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -38508,6 +41666,17 @@ func (p *storageDomainDisksServiceAddRequest) Send() (*storageDomainDisksService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainDisksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainDisksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -38667,6 +41836,17 @@ func (p *storageDomainDisksServiceListRequest) Send() (*storageDomainDisksServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainDisksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainDisksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -38838,6 +42018,17 @@ func (p *vmGraphicsConsolesServiceAddRequest) Send() (*vmGraphicsConsolesService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmGraphicsConsolesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmGraphicsConsolesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -38993,6 +42184,17 @@ func (p *vmGraphicsConsolesServiceListRequest) Send() (*vmGraphicsConsolesServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmGraphicsConsolesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmGraphicsConsolesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -39172,6 +42374,17 @@ func (p *statisticServiceGetRequest) Send() (*statisticServiceGetResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.statisticService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.statisticService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -39347,6 +42560,17 @@ func (p *schedulingPolicyUnitsServiceListRequest) Send() (*schedulingPolicyUnits
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.schedulingPolicyUnitsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.schedulingPolicyUnitsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -39520,6 +42744,17 @@ func (p *affinityLabelVmsServiceAddRequest) Send() (*affinityLabelVmsServiceAddR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelVmsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelVmsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -39649,6 +42884,17 @@ func (p *affinityLabelVmsServiceListRequest) Send() (*affinityLabelVmsServiceLis
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelVmsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelVmsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -39863,6 +43109,17 @@ func (p *vmNicsServiceAddRequest) Send() (*vmNicsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNicsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNicsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -40086,6 +43343,17 @@ func (p *vmNicsServiceListRequest) Send() (*vmNicsServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNicsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNicsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -40260,6 +43528,17 @@ func (p *moveableServiceMoveRequest) Send() (*moveableServiceMoveResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.moveableService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.moveableService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -40415,6 +43694,17 @@ func (p *eventServiceGetRequest) Send() (*eventServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.eventService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.eventService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -40596,6 +43886,17 @@ func (p *eventServiceRemoveRequest) Send() (*eventServiceRemoveResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.eventService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.eventService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -40740,6 +44041,17 @@ func (p *snapshotServiceGetRequest) Send() (*snapshotServiceGetResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -40875,6 +44187,17 @@ func (p *snapshotServiceRemoveRequest) Send() (*snapshotServiceRemoveResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -41024,6 +44347,17 @@ func (p *snapshotServiceRestoreRequest) Send() (*snapshotServiceRestoreResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -41217,6 +44551,17 @@ func (p *templateNicsServiceAddRequest) Send() (*templateNicsServiceAddResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateNicsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateNicsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -41356,6 +44701,17 @@ func (p *templateNicsServiceListRequest) Send() (*templateNicsServiceListRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateNicsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateNicsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -41548,6 +44904,17 @@ func (p *macPoolsServiceAddRequest) Send() (*macPoolsServiceAddResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.macPoolsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.macPoolsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -41731,6 +45098,17 @@ func (p *macPoolsServiceListRequest) Send() (*macPoolsServiceListResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.macPoolsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.macPoolsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -41824,7 +45202,7 @@ func NewTemplateService(connection *Connection, path string) *templateService {
 
 //
 // Exports a template to the data center export domain.
-// For example, the operation can be facilitated using the following request:
+// For example, send the following request:
 // [source]
 // ----
 // POST /ovirt-engine/api/templates/123/export
@@ -41927,6 +45305,17 @@ func (p *templateServiceExportRequest) Send() (*templateServiceExportResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -41944,7 +45333,7 @@ func (p *templateServiceExportRequest) MustSend() *templateServiceExportResponse
 
 //
 // Exports a template to the data center export domain.
-// For example, the operation can be facilitated using the following request:
+// For example, send the following request:
 // [source]
 // ----
 // POST /ovirt-engine/api/templates/123/export
@@ -41963,7 +45352,7 @@ type templateServiceExportResponse struct {
 
 //
 // Exports a template to the data center export domain.
-// For example, the operation can be facilitated using the following request:
+// For example, send the following request:
 // [source]
 // ----
 // POST /ovirt-engine/api/templates/123/export
@@ -42068,6 +45457,17 @@ func (p *templateServiceGetRequest) Send() (*templateServiceGetResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -42200,6 +45600,17 @@ func (p *templateServiceRemoveRequest) Send() (*templateServiceRemoveResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -42240,10 +45651,297 @@ func (p *templateService) Remove() *templateServiceRemoveRequest {
 }
 
 //
+// Exports a template to an export domain.
+//
+type templateServiceExportToExportDomainRequest struct {
+	templateService *templateService
+	header          map[string]string
+	query           map[string]string
+	exclusive       *bool
+	storageDomain   *StorageDomain
+}
+
+func (p *templateServiceExportToExportDomainRequest) Header(key, value string) *templateServiceExportToExportDomainRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *templateServiceExportToExportDomainRequest) Query(key, value string) *templateServiceExportToExportDomainRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *templateServiceExportToExportDomainRequest) Exclusive(exclusive bool) *templateServiceExportToExportDomainRequest {
+	p.exclusive = &exclusive
+	return p
+}
+
+func (p *templateServiceExportToExportDomainRequest) StorageDomain(storageDomain *StorageDomain) *templateServiceExportToExportDomainRequest {
+	p.storageDomain = storageDomain
+	return p
+}
+
+func (p *templateServiceExportToExportDomainRequest) Send() (*templateServiceExportToExportDomainResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/toexportdomain", p.templateService.connection.URL(), p.templateService.path)
+	actionBuilder := NewActionBuilder()
+	if p.exclusive != nil {
+		actionBuilder.Exclusive(*p.exclusive)
+	}
+	actionBuilder.StorageDomain(p.storageDomain)
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.templateService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.templateService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.templateService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.templateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	_, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	return new(templateServiceExportToExportDomainResponse), nil
+}
+
+func (p *templateServiceExportToExportDomainRequest) MustSend() *templateServiceExportToExportDomainResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Exports a template to an export domain.
+//
+type templateServiceExportToExportDomainResponse struct {
+}
+
+//
+// Exports a template to an export domain.
+//
+func (p *templateService) ExportToExportDomain() *templateServiceExportToExportDomainRequest {
+	return &templateServiceExportToExportDomainRequest{templateService: p}
+}
+
+//
+// Exports a template as an OVA file to a given path on a specified host.
+//
+type templateServiceExportToPathOnHostRequest struct {
+	templateService *templateService
+	header          map[string]string
+	query           map[string]string
+	directory       *string
+	exclusive       *bool
+	filename        *string
+	host            *Host
+	storageDomain   *StorageDomain
+}
+
+func (p *templateServiceExportToPathOnHostRequest) Header(key, value string) *templateServiceExportToPathOnHostRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *templateServiceExportToPathOnHostRequest) Query(key, value string) *templateServiceExportToPathOnHostRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *templateServiceExportToPathOnHostRequest) Directory(directory string) *templateServiceExportToPathOnHostRequest {
+	p.directory = &directory
+	return p
+}
+
+func (p *templateServiceExportToPathOnHostRequest) Exclusive(exclusive bool) *templateServiceExportToPathOnHostRequest {
+	p.exclusive = &exclusive
+	return p
+}
+
+func (p *templateServiceExportToPathOnHostRequest) Filename(filename string) *templateServiceExportToPathOnHostRequest {
+	p.filename = &filename
+	return p
+}
+
+func (p *templateServiceExportToPathOnHostRequest) Host(host *Host) *templateServiceExportToPathOnHostRequest {
+	p.host = host
+	return p
+}
+
+func (p *templateServiceExportToPathOnHostRequest) StorageDomain(storageDomain *StorageDomain) *templateServiceExportToPathOnHostRequest {
+	p.storageDomain = storageDomain
+	return p
+}
+
+func (p *templateServiceExportToPathOnHostRequest) Send() (*templateServiceExportToPathOnHostResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/topathonhost", p.templateService.connection.URL(), p.templateService.path)
+	actionBuilder := NewActionBuilder()
+	if p.directory != nil {
+		actionBuilder.Directory(*p.directory)
+	}
+	if p.exclusive != nil {
+		actionBuilder.Exclusive(*p.exclusive)
+	}
+	if p.filename != nil {
+		actionBuilder.Filename(*p.filename)
+	}
+	actionBuilder.Host(p.host)
+	actionBuilder.StorageDomain(p.storageDomain)
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.templateService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.templateService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.templateService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.templateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	_, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	return new(templateServiceExportToPathOnHostResponse), nil
+}
+
+func (p *templateServiceExportToPathOnHostRequest) MustSend() *templateServiceExportToPathOnHostResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Exports a template as an OVA file to a given path on a specified host.
+//
+type templateServiceExportToPathOnHostResponse struct {
+}
+
+//
+// Exports a template as an OVA file to a given path on a specified host.
+//
+func (p *templateService) ExportToPathOnHost() *templateServiceExportToPathOnHostRequest {
+	return &templateServiceExportToPathOnHostRequest{templateService: p}
+}
+
+//
 // Updates the template.
 // The `name`, `description`, `type`, `memory`, `cpu`, `topology`, `os`, `high_availability`, `display`,
-// `stateless`, `usb` and `timezone` elements can be updated after a template has been created.
-// For example, to update a template to so that it has 1 GiB of memory send a request like this:
+// `stateless`, `usb`, and `timezone` elements can be updated after a template has been created.
+// For example, to update a template so that it has 1 GiB of memory send a request like this:
 // [source]
 // ----
 // PUT /ovirt-engine/api/templates/123
@@ -42353,6 +46051,17 @@ func (p *templateServiceUpdateRequest) Send() (*templateServiceUpdateResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -42379,8 +46088,8 @@ func (p *templateServiceUpdateRequest) MustSend() *templateServiceUpdateResponse
 //
 // Updates the template.
 // The `name`, `description`, `type`, `memory`, `cpu`, `topology`, `os`, `high_availability`, `display`,
-// `stateless`, `usb` and `timezone` elements can be updated after a template has been created.
-// For example, to update a template to so that it has 1 GiB of memory send a request like this:
+// `stateless`, `usb`, and `timezone` elements can be updated after a template has been created.
+// For example, to update a template so that it has 1 GiB of memory send a request like this:
 // [source]
 // ----
 // PUT /ovirt-engine/api/templates/123
@@ -42424,8 +46133,8 @@ func (p *templateServiceUpdateResponse) MustTemplate() *Template {
 //
 // Updates the template.
 // The `name`, `description`, `type`, `memory`, `cpu`, `topology`, `os`, `high_availability`, `display`,
-// `stateless`, `usb` and `timezone` elements can be updated after a template has been created.
-// For example, to update a template to so that it has 1 GiB of memory send a request like this:
+// `stateless`, `usb`, and `timezone` elements can be updated after a template has been created.
+// For example, to update a template so that it has 1 GiB of memory send a request like this:
 // [source]
 // ----
 // PUT /ovirt-engine/api/templates/123
@@ -42453,14 +46162,14 @@ func (p *templateService) Update() *templateServiceUpdateRequest {
 }
 
 //
-// Returns a reference to the service that manages the CDROMs that are associated with the template.
+// Returns a reference to the service that manages the CD-ROMs that are associated with the template.
 //
 func (op *templateService) CdromsService() *templateCdromsService {
 	return NewTemplateCdromsService(op.connection, fmt.Sprintf("%s/cdroms", op.path))
 }
 
 //
-// Reference to the service that manages a specific
+// Returns a reference to the service that manages a specific
 // disk attachment of the template.
 //
 func (op *templateService) DiskAttachmentsService() *templateDiskAttachmentsService {
@@ -42662,6 +46371,17 @@ func (p *affinityGroupVmsServiceAddRequest) Send() (*affinityGroupVmsServiceAddR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityGroupVmsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityGroupVmsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -42821,6 +46541,17 @@ func (p *affinityGroupVmsServiceListRequest) Send() (*affinityGroupVmsServiceLis
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityGroupVmsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityGroupVmsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -43028,6 +46759,17 @@ func (p *imageTransfersServiceAddRequest) Send() (*imageTransfersServiceAddRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageTransfersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransfersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -43227,6 +46969,17 @@ func (p *imageTransfersServiceAddForDiskRequest) Send() (*imageTransfersServiceA
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageTransfersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransfersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -43351,6 +47104,17 @@ func (p *imageTransfersServiceAddForImageRequest) Send() (*imageTransfersService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageTransfersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransfersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -43475,6 +47239,17 @@ func (p *imageTransfersServiceAddForSnapshotRequest) Send() (*imageTransfersServ
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageTransfersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransfersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -43596,6 +47371,17 @@ func (p *imageTransfersServiceListRequest) Send() (*imageTransfersServiceListRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageTransfersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransfersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -43770,6 +47556,17 @@ func (p *affinityLabelHostServiceGetRequest) Send() (*affinityLabelHostServiceGe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelHostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelHostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -43888,6 +47685,17 @@ func (p *affinityLabelHostServiceRemoveRequest) Send() (*affinityLabelHostServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelHostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelHostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -44026,6 +47834,17 @@ func (p *storageDomainServerConnectionsServiceAddRequest) Send() (*storageDomain
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainServerConnectionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainServerConnectionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -44163,6 +47982,17 @@ func (p *storageDomainServerConnectionsServiceListRequest) Send() (*storageDomai
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainServerConnectionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainServerConnectionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -44332,6 +48162,17 @@ func (p *vmDisksServiceAddRequest) Send() (*vmDisksServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmDisksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmDisksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -44469,6 +48310,17 @@ func (p *vmDisksServiceListRequest) Send() (*vmDisksServiceListResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmDisksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmDisksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -44655,6 +48507,17 @@ func (p *vmPoolsServiceAddRequest) Send() (*vmPoolsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmPoolsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmPoolsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -44869,6 +48732,17 @@ func (p *vmPoolsServiceListRequest) Send() (*vmPoolsServiceListResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmPoolsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmPoolsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -45097,6 +48971,17 @@ func (p *vmCdromServiceGetRequest) Send() (*vmCdromServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmCdromService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmCdromService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -45311,6 +49196,17 @@ func (p *vmCdromServiceUpdateRequest) Send() (*vmCdromServiceUpdateResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmCdromService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmCdromService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -45566,6 +49462,17 @@ func (p *storageDomainTemplatesServiceListRequest) Send() (*storageDomainTemplat
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainTemplatesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainTemplatesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -45732,6 +49639,17 @@ func (p *quotaStorageLimitServiceGetRequest) Send() (*quotaStorageLimitServiceGe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaStorageLimitService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaStorageLimitService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -45857,6 +49775,17 @@ func (p *quotaStorageLimitServiceRemoveRequest) Send() (*quotaStorageLimitServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaStorageLimitService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaStorageLimitService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -46002,6 +49931,17 @@ func (p *tagServiceGetRequest) Send() (*tagServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.tagService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.tagService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -46156,6 +50096,17 @@ func (p *tagServiceRemoveRequest) Send() (*tagServiceRemoveResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.tagService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.tagService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -46306,6 +50257,17 @@ func (p *tagServiceUpdateRequest) Send() (*tagServiceUpdateResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.tagService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.tagService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -46521,6 +50483,17 @@ func (p *vmServiceCancelMigrationRequest) Send() (*vmServiceCancelMigrationRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -46660,6 +50633,17 @@ func (p *vmServiceCloneRequest) Send() (*vmServiceCloneResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -46772,6 +50756,17 @@ func (p *vmServiceCommitSnapshotRequest) Send() (*vmServiceCommitSnapshotRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -46897,6 +50892,17 @@ func (p *vmServiceDetachRequest) Send() (*vmServiceDetachResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -47089,6 +51095,17 @@ func (p *vmServiceExportRequest) Send() (*vmServiceExportResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -47282,6 +51299,17 @@ func (p *vmServiceFreezeFilesystemsRequest) Send() (*vmServiceFreezeFilesystemsR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -47441,6 +51469,17 @@ func (p *vmServiceGetRequest) Send() (*vmServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -47591,6 +51630,17 @@ func (p *vmServiceLogonRequest) Send() (*vmServiceLogonResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -47753,6 +51803,17 @@ func (p *vmServiceMaintenanceRequest) Send() (*vmServiceMaintenanceResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -47925,6 +51986,17 @@ func (p *vmServiceMigrateRequest) Send() (*vmServiceMigrateResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -48111,6 +52183,17 @@ func (p *vmServicePreviewSnapshotRequest) Send() (*vmServicePreviewSnapshotRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -48243,6 +52326,17 @@ func (p *vmServiceRebootRequest) Send() (*vmServiceRebootResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -48395,6 +52489,17 @@ func (p *vmServiceRemoveRequest) Send() (*vmServiceRemoveResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -48520,6 +52625,17 @@ func (p *vmServiceReorderMacAddressesRequest) Send() (*vmServiceReorderMacAddres
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -48642,6 +52758,17 @@ func (p *vmServiceShutdownRequest) Send() (*vmServiceShutdownResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -48848,6 +52975,17 @@ func (p *vmServiceStartRequest) Send() (*vmServiceStartResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -48996,6 +53134,17 @@ func (p *vmServiceStopRequest) Send() (*vmServiceStopResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -49143,6 +53292,17 @@ func (p *vmServiceSuspendRequest) Send() (*vmServiceSuspendResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -49292,6 +53452,17 @@ func (p *vmServiceThawFilesystemsRequest) Send() (*vmServiceThawFilesystemsRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -49468,6 +53639,17 @@ func (p *vmServiceTicketRequest) Send() (*vmServiceTicketResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -49686,6 +53868,17 @@ func (p *vmServiceExportToExportDomainRequest) Send() (*vmServiceExportToExportD
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -49849,6 +54042,17 @@ func (p *vmServiceExportToPathOnHostRequest) Send() (*vmServiceExportToPathOnHos
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -49963,6 +54167,17 @@ func (p *vmServiceUndoSnapshotRequest) Send() (*vmServiceUndoSnapshotResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -50093,6 +54308,17 @@ func (p *vmServiceUpdateRequest) Send() (*vmServiceUpdateResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -50444,6 +54670,17 @@ func (p *hostHookServiceGetRequest) Send() (*hostHookServiceGetResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostHookService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostHookService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -50596,6 +54833,17 @@ func (p *imageServiceGetRequest) Send() (*imageServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -50777,6 +55025,17 @@ func (p *imageServiceImportRequest) Send() (*imageServiceImportResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -50948,6 +55207,17 @@ func (p *qossServiceAddRequest) Send() (*qossServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.qossService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.qossService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -51130,6 +55400,17 @@ func (p *qossServiceListRequest) Send() (*qossServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.qossService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.qossService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -51337,6 +55618,17 @@ func (p *bookmarkServiceGetRequest) Send() (*bookmarkServiceGetResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.bookmarkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.bookmarkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -51494,6 +55786,17 @@ func (p *bookmarkServiceRemoveRequest) Send() (*bookmarkServiceRemoveResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.bookmarkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.bookmarkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -51638,6 +55941,17 @@ func (p *bookmarkServiceUpdateRequest) Send() (*bookmarkServiceUpdateResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.bookmarkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.bookmarkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -51818,6 +56132,17 @@ func (p *networkLabelServiceGetRequest) Send() (*networkLabelServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkLabelService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkLabelService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -51949,6 +56274,17 @@ func (p *networkLabelServiceRemoveRequest) Send() (*networkLabelServiceRemoveRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkLabelService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkLabelService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -52093,6 +56429,17 @@ func (p *storageServerConnectionServiceGetRequest) Send() (*storageServerConnect
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -52140,6 +56487,162 @@ func (p *storageServerConnectionServiceGetResponse) MustConection() *StorageConn
 //
 func (p *storageServerConnectionService) Get() *storageServerConnectionServiceGetRequest {
 	return &storageServerConnectionServiceGetRequest{storageServerConnectionService: p}
+}
+
+//
+// Update the specified Glusterfs storage connection in the system.
+//
+type storageServerConnectionServiceUpdateGlusterfsRequest struct {
+	storageServerConnectionService *storageServerConnectionService
+	header                         map[string]string
+	query                          map[string]string
+	async                          *bool
+	connection                     *StorageConnection
+	force                          *bool
+}
+
+func (p *storageServerConnectionServiceUpdateGlusterfsRequest) Header(key, value string) *storageServerConnectionServiceUpdateGlusterfsRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *storageServerConnectionServiceUpdateGlusterfsRequest) Query(key, value string) *storageServerConnectionServiceUpdateGlusterfsRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *storageServerConnectionServiceUpdateGlusterfsRequest) Async(async bool) *storageServerConnectionServiceUpdateGlusterfsRequest {
+	p.async = &async
+	return p
+}
+
+func (p *storageServerConnectionServiceUpdateGlusterfsRequest) Connection(connection *StorageConnection) *storageServerConnectionServiceUpdateGlusterfsRequest {
+	p.connection = connection
+	return p
+}
+
+func (p *storageServerConnectionServiceUpdateGlusterfsRequest) Force(force bool) *storageServerConnectionServiceUpdateGlusterfsRequest {
+	p.force = &force
+	return p
+}
+
+func (p *storageServerConnectionServiceUpdateGlusterfsRequest) Send() (*storageServerConnectionServiceUpdateGlusterfsResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/glusterfs", p.storageServerConnectionService.connection.URL(), p.storageServerConnectionService.path)
+	actionBuilder := NewActionBuilder()
+	if p.async != nil {
+		actionBuilder.Async(*p.async)
+	}
+	actionBuilder.Connection(p.connection)
+	if p.force != nil {
+		actionBuilder.Force(*p.force)
+	}
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.storageServerConnectionService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.storageServerConnectionService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.storageServerConnectionService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.storageServerConnectionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	action, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	result := action.MustConnection()
+	return &storageServerConnectionServiceUpdateGlusterfsResponse{connection: result}, nil
+}
+
+func (p *storageServerConnectionServiceUpdateGlusterfsRequest) MustSend() *storageServerConnectionServiceUpdateGlusterfsResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Update the specified Glusterfs storage connection in the system.
+//
+type storageServerConnectionServiceUpdateGlusterfsResponse struct {
+	connection *StorageConnection
+}
+
+func (p *storageServerConnectionServiceUpdateGlusterfsResponse) Connection() (*StorageConnection, bool) {
+	if p.connection != nil {
+		return p.connection, true
+	}
+	return nil, false
+}
+
+func (p *storageServerConnectionServiceUpdateGlusterfsResponse) MustConnection() *StorageConnection {
+	if p.connection == nil {
+		panic("connection in response does not exist")
+	}
+	return p.connection
+}
+
+//
+// Update the specified Glusterfs storage connection in the system.
+//
+func (p *storageServerConnectionService) UpdateGlusterfs() *storageServerConnectionServiceUpdateGlusterfsRequest {
+	return &storageServerConnectionServiceUpdateGlusterfsRequest{storageServerConnectionService: p}
 }
 
 //
@@ -52243,6 +56746,17 @@ func (p *storageServerConnectionServiceUpdateIscsiRequest) Send() (*storageServe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -52388,6 +56902,17 @@ func (p *storageServerConnectionServiceUpdateLocalRequest) Send() (*storageServe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -52433,7 +56958,7 @@ func (p *storageServerConnectionService) UpdateLocal() *storageServerConnectionS
 }
 
 //
-// Update the specified nfs storage connection in the system.
+// Update the specified NFS storage connection in the system.
 //
 type storageServerConnectionServiceUpdateNfsRequest struct {
 	storageServerConnectionService *storageServerConnectionService
@@ -52533,6 +57058,17 @@ func (p *storageServerConnectionServiceUpdateNfsRequest) Send() (*storageServerC
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -52550,7 +57086,7 @@ func (p *storageServerConnectionServiceUpdateNfsRequest) MustSend() *storageServ
 }
 
 //
-// Update the specified nfs storage connection in the system.
+// Update the specified NFS storage connection in the system.
 //
 type storageServerConnectionServiceUpdateNfsResponse struct {
 	connection *StorageConnection
@@ -52571,7 +57107,7 @@ func (p *storageServerConnectionServiceUpdateNfsResponse) MustConnection() *Stor
 }
 
 //
-// Update the specified nfs storage connection in the system.
+// Update the specified NFS storage connection in the system.
 //
 func (p *storageServerConnectionService) UpdateNfs() *storageServerConnectionServiceUpdateNfsRequest {
 	return &storageServerConnectionServiceUpdateNfsRequest{storageServerConnectionService: p}
@@ -52666,6 +57202,17 @@ func (p *storageServerConnectionServiceRemoveRequest) Send() (*storageServerConn
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -52703,7 +57250,7 @@ func (p *storageServerConnectionService) Remove() *storageServerConnectionServic
 
 //
 // Updates the storage connection.
-// For example, to change the address of the storage server send a request like this:
+// For example, to change the address of an NFS storage server, send a request like this:
 // [source,xml]
 // ----
 // PUT /ovirt-engine/api/storageconnections/123
@@ -52713,9 +57260,19 @@ func (p *storageServerConnectionService) Remove() *storageServerConnectionServic
 // ----
 // <storage_connection>
 //   <address>mynewnfs.example.com</address>
-//   <host>
-//     <name>myhost</name>
-//   </host>
+// </storage_connection>
+// ----
+// To change the connection of an iSCSI storage server, send a request like this:
+// [source,xml]
+// ----
+// PUT /ovirt-engine/api/storageconnections/123
+// ----
+// With a request body like this:
+// [source,xml]
+// ----
+// <storage_connection>
+//   <port>3260</port>
+//   <target>iqn.2017-01.com.myhost:444</target>
 // </storage_connection>
 // ----
 //
@@ -52816,6 +57373,17 @@ func (p *storageServerConnectionServiceUpdateRequest) Send() (*storageServerConn
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -52841,7 +57409,7 @@ func (p *storageServerConnectionServiceUpdateRequest) MustSend() *storageServerC
 
 //
 // Updates the storage connection.
-// For example, to change the address of the storage server send a request like this:
+// For example, to change the address of an NFS storage server, send a request like this:
 // [source,xml]
 // ----
 // PUT /ovirt-engine/api/storageconnections/123
@@ -52851,9 +57419,19 @@ func (p *storageServerConnectionServiceUpdateRequest) MustSend() *storageServerC
 // ----
 // <storage_connection>
 //   <address>mynewnfs.example.com</address>
-//   <host>
-//     <name>myhost</name>
-//   </host>
+// </storage_connection>
+// ----
+// To change the connection of an iSCSI storage server, send a request like this:
+// [source,xml]
+// ----
+// PUT /ovirt-engine/api/storageconnections/123
+// ----
+// With a request body like this:
+// [source,xml]
+// ----
+// <storage_connection>
+//   <port>3260</port>
+//   <target>iqn.2017-01.com.myhost:444</target>
 // </storage_connection>
 // ----
 //
@@ -52877,7 +57455,7 @@ func (p *storageServerConnectionServiceUpdateResponse) MustConnection() *Storage
 
 //
 // Updates the storage connection.
-// For example, to change the address of the storage server send a request like this:
+// For example, to change the address of an NFS storage server, send a request like this:
 // [source,xml]
 // ----
 // PUT /ovirt-engine/api/storageconnections/123
@@ -52887,9 +57465,19 @@ func (p *storageServerConnectionServiceUpdateResponse) MustConnection() *Storage
 // ----
 // <storage_connection>
 //   <address>mynewnfs.example.com</address>
-//   <host>
-//     <name>myhost</name>
-//   </host>
+// </storage_connection>
+// ----
+// To change the connection of an iSCSI storage server, send a request like this:
+// [source,xml]
+// ----
+// PUT /ovirt-engine/api/storageconnections/123
+// ----
+// With a request body like this:
+// [source,xml]
+// ----
+// <storage_connection>
+//   <port>3260</port>
+//   <target>iqn.2017-01.com.myhost:444</target>
 // </storage_connection>
 // ----
 //
@@ -52898,7 +57486,7 @@ func (p *storageServerConnectionService) Update() *storageServerConnectionServic
 }
 
 //
-// Update the specified vfs storage connection in the system.
+// Update the specified VFS storage connection in the system.
 //
 type storageServerConnectionServiceUpdateVfsRequest struct {
 	storageServerConnectionService *storageServerConnectionService
@@ -52998,6 +57586,17 @@ func (p *storageServerConnectionServiceUpdateVfsRequest) Send() (*storageServerC
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -53015,7 +57614,7 @@ func (p *storageServerConnectionServiceUpdateVfsRequest) MustSend() *storageServ
 }
 
 //
-// Update the specified vfs storage connection in the system.
+// Update the specified VFS storage connection in the system.
 //
 type storageServerConnectionServiceUpdateVfsResponse struct {
 	connection *StorageConnection
@@ -53036,7 +57635,7 @@ func (p *storageServerConnectionServiceUpdateVfsResponse) MustConnection() *Stor
 }
 
 //
-// Update the specified vfs storage connection in the system.
+// Update the specified VFS storage connection in the system.
 //
 func (p *storageServerConnectionService) UpdateVfs() *storageServerConnectionServiceUpdateVfsRequest {
 	return &storageServerConnectionServiceUpdateVfsRequest{storageServerConnectionService: p}
@@ -53160,6 +57759,17 @@ func (p *clusterNetworksServiceAddRequest) Send() (*clusterNetworksServiceAddRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterNetworksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterNetworksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -53319,6 +57929,17 @@ func (p *clusterNetworksServiceListRequest) Send() (*clusterNetworksServiceListR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterNetworksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterNetworksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -53489,6 +58110,17 @@ func (p *clusterExternalProvidersServiceListRequest) Send() (*clusterExternalPro
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterExternalProvidersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterExternalProvidersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -53658,6 +58290,17 @@ func (p *snapshotCdromsServiceListRequest) Send() (*snapshotCdromsServiceListRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotCdromsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotCdromsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -53839,6 +58482,17 @@ func (p *externalProviderCertificateServiceGetRequest) Send() (*externalProvider
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalProviderCertificateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalProviderCertificateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -54073,6 +58727,17 @@ func (p *snapshotsServiceAddRequest) Send() (*snapshotsServiceAddResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -54320,6 +58985,17 @@ func (p *snapshotsServiceListRequest) Send() (*snapshotsServiceListResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -54486,6 +59162,17 @@ func (p *hostNumaNodeServiceGetRequest) Send() (*hostNumaNodeServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostNumaNodeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostNumaNodeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -54651,6 +59338,17 @@ func (p *templateGraphicsConsoleServiceGetRequest) Send() (*templateGraphicsCons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateGraphicsConsoleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateGraphicsConsoleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -54779,6 +59477,17 @@ func (p *templateGraphicsConsoleServiceRemoveRequest) Send() (*templateGraphicsC
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateGraphicsConsoleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateGraphicsConsoleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -54930,6 +59639,17 @@ func (p *vmGraphicsConsoleServiceGetRequest) Send() (*vmGraphicsConsoleServiceGe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmGraphicsConsoleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmGraphicsConsoleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -55077,6 +59797,17 @@ func (p *vmGraphicsConsoleServiceProxyTicketRequest) Send() (*vmGraphicsConsoleS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmGraphicsConsoleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmGraphicsConsoleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -55259,6 +59990,17 @@ func (p *vmGraphicsConsoleServiceRemoteViewerConnectionFileRequest) Send() (*vmG
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmGraphicsConsoleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmGraphicsConsoleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -55509,6 +60251,17 @@ func (p *vmGraphicsConsoleServiceRemoveRequest) Send() (*vmGraphicsConsoleServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmGraphicsConsoleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmGraphicsConsoleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -55638,6 +60391,17 @@ func (p *vmGraphicsConsoleServiceTicketRequest) Send() (*vmGraphicsConsoleServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmGraphicsConsoleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmGraphicsConsoleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -55815,6 +60579,17 @@ func (p *quotaClusterLimitServiceGetRequest) Send() (*quotaClusterLimitServiceGe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaClusterLimitService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaClusterLimitService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -55940,6 +60715,17 @@ func (p *quotaClusterLimitServiceRemoveRequest) Send() (*quotaClusterLimitServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaClusterLimitService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaClusterLimitService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -56089,6 +60875,17 @@ func (p *qosServiceGetRequest) Send() (*qosServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.qosService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.qosService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -56253,6 +61050,17 @@ func (p *qosServiceRemoveRequest) Send() (*qosServiceRemoveResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.qosService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.qosService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -56405,6 +61213,17 @@ func (p *qosServiceUpdateRequest) Send() (*qosServiceUpdateResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.qosService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.qosService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -56618,6 +61437,17 @@ func (p *hostNicsServiceListRequest) Send() (*hostNicsServiceListResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostNicsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostNicsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -56788,6 +61618,17 @@ func (p *externalNetworkProviderConfigurationsServiceListRequest) Send() (*exter
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalNetworkProviderConfigurationsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalNetworkProviderConfigurationsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -56954,6 +61795,17 @@ func (p *templateNicServiceGetRequest) Send() (*templateNicServiceGetResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -57079,6 +61931,17 @@ func (p *templateNicServiceRemoveRequest) Send() (*templateNicServiceRemoveRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -57198,6 +62061,17 @@ func (p *templateNicServiceUpdateRequest) Send() (*templateNicServiceUpdateRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -57369,6 +62243,17 @@ func (p *bookmarksServiceAddRequest) Send() (*bookmarksServiceAddResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.bookmarksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.bookmarksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -57550,6 +62435,17 @@ func (p *bookmarksServiceListRequest) Send() (*bookmarksServiceListResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.bookmarksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.bookmarksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -57766,6 +62662,17 @@ func (p *snapshotDisksServiceListRequest) Send() (*snapshotDisksServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotDisksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotDisksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -57936,6 +62843,17 @@ func (p *assignedCpuProfilesServiceAddRequest) Send() (*assignedCpuProfilesServi
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedCpuProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedCpuProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -58075,6 +62993,17 @@ func (p *assignedCpuProfilesServiceListRequest) Send() (*assignedCpuProfilesServ
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedCpuProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedCpuProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -58260,6 +63189,17 @@ func (p *nicNetworkFilterParametersServiceAddRequest) Send() (*nicNetworkFilterP
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.nicNetworkFilterParametersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.nicNetworkFilterParametersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -58417,6 +63357,17 @@ func (p *nicNetworkFilterParametersServiceListRequest) Send() (*nicNetworkFilter
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.nicNetworkFilterParametersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.nicNetworkFilterParametersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -58586,6 +63537,17 @@ func (p *templateDiskAttachmentServiceGetRequest) Send() (*templateDiskAttachmen
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateDiskAttachmentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateDiskAttachmentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -58731,6 +63693,17 @@ func (p *templateDiskAttachmentServiceRemoveRequest) Send() (*templateDiskAttach
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateDiskAttachmentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateDiskAttachmentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -58879,6 +63852,17 @@ func (p *virtualFunctionAllowedNetworkServiceGetRequest) Send() (*virtualFunctio
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.virtualFunctionAllowedNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.virtualFunctionAllowedNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -59004,6 +63988,17 @@ func (p *virtualFunctionAllowedNetworkServiceRemoveRequest) Send() (*virtualFunc
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.virtualFunctionAllowedNetworkService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.virtualFunctionAllowedNetworkService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -59153,6 +64148,17 @@ func (p *networkLabelsServiceAddRequest) Send() (*networkLabelsServiceAddRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkLabelsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkLabelsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -59316,6 +64322,17 @@ func (p *networkLabelsServiceListRequest) Send() (*networkLabelsServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkLabelsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkLabelsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -59524,6 +64541,17 @@ func (p *clustersServiceAddRequest) Send() (*clustersServiceAddResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clustersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clustersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -59768,6 +64796,17 @@ func (p *clustersServiceListRequest) Send() (*clustersServiceListResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clustersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clustersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -59940,6 +64979,17 @@ func (p *assignedAffinityLabelServiceGetRequest) Send() (*assignedAffinityLabelS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedAffinityLabelService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedAffinityLabelService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -60058,6 +65108,17 @@ func (p *assignedAffinityLabelServiceRemoveRequest) Send() (*assignedAffinityLab
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedAffinityLabelService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedAffinityLabelService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -60202,6 +65263,17 @@ func (p *weightServiceGetRequest) Send() (*weightServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.weightService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.weightService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -60327,6 +65399,17 @@ func (p *weightServiceRemoveRequest) Send() (*weightServiceRemoveResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.weightService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.weightService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -60459,6 +65542,17 @@ func (p *diskProfileServiceGetRequest) Send() (*diskProfileServiceGetResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -60584,6 +65678,17 @@ func (p *diskProfileServiceRemoveRequest) Send() (*diskProfileServiceRemoveRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -60703,6 +65808,17 @@ func (p *diskProfileServiceUpdateRequest) Send() (*diskProfileServiceUpdateRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -60781,7 +65897,7 @@ func (op *diskProfileService) String() string {
 }
 
 //
-// Manages the set of storage domains of the system.
+// Manages the set of storage domains in the system.
 //
 type storageDomainsService struct {
 	baseService
@@ -60796,18 +65912,18 @@ func NewStorageDomainsService(connection *Connection, path string) *storageDomai
 
 //
 // Adds a new storage domain.
-// Creation of a new <<types/storage_domain,StorageDomain>> requires the `name`, `type`, `host` and `storage`
-// attributes. Identify the `host` attribute with the `id` or `name` attributes. In oVirt 3.6 and later you can
-// enable the wipe after delete option by default on the storage domain. To configure this, specify
+// Creation of a new <<types/storage_domain,StorageDomain>> requires the `name`, `type`, `host`, and `storage`
+// attributes. Identify the `host` attribute with the `id` or `name` attributes. In {product-name} 3.6 and
+// later you can enable the wipe after delete option by default on the storage domain. To configure this, specify
 // `wipe_after_delete` in the POST request. This option can be edited after the domain is created, but doing so will
 // not change the wipe after delete property of disks that already exist.
-// To add a new storage domain with specified `name`, `type`, `storage.type`, `storage.address` and `storage.path`
-// and by using a host with an id `123`, send a request as follows:
+// To add a new storage domain with specified `name`, `type`, `storage.type`, `storage.address`, and `storage.path`,
+// and using a host with an id `123`, send a request like this:
 // [source]
 // ----
 // POST /ovirt-engine/api/storageDomains
 // ----
-// With a request body as follows:
+// With a request body like this:
 // [source,xml]
 // ----
 // <storage_domain>
@@ -60935,6 +66051,17 @@ func (p *storageDomainsServiceAddRequest) Send() (*storageDomainsServiceAddRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -60960,18 +66087,18 @@ func (p *storageDomainsServiceAddRequest) MustSend() *storageDomainsServiceAddRe
 
 //
 // Adds a new storage domain.
-// Creation of a new <<types/storage_domain,StorageDomain>> requires the `name`, `type`, `host` and `storage`
-// attributes. Identify the `host` attribute with the `id` or `name` attributes. In oVirt 3.6 and later you can
-// enable the wipe after delete option by default on the storage domain. To configure this, specify
+// Creation of a new <<types/storage_domain,StorageDomain>> requires the `name`, `type`, `host`, and `storage`
+// attributes. Identify the `host` attribute with the `id` or `name` attributes. In {product-name} 3.6 and
+// later you can enable the wipe after delete option by default on the storage domain. To configure this, specify
 // `wipe_after_delete` in the POST request. This option can be edited after the domain is created, but doing so will
 // not change the wipe after delete property of disks that already exist.
-// To add a new storage domain with specified `name`, `type`, `storage.type`, `storage.address` and `storage.path`
-// and by using a host with an id `123`, send a request as follows:
+// To add a new storage domain with specified `name`, `type`, `storage.type`, `storage.address`, and `storage.path`,
+// and using a host with an id `123`, send a request like this:
 // [source]
 // ----
 // POST /ovirt-engine/api/storageDomains
 // ----
-// With a request body as follows:
+// With a request body like this:
 // [source,xml]
 // ----
 // <storage_domain>
@@ -61042,18 +66169,18 @@ func (p *storageDomainsServiceAddResponse) MustStorageDomain() *StorageDomain {
 
 //
 // Adds a new storage domain.
-// Creation of a new <<types/storage_domain,StorageDomain>> requires the `name`, `type`, `host` and `storage`
-// attributes. Identify the `host` attribute with the `id` or `name` attributes. In oVirt 3.6 and later you can
-// enable the wipe after delete option by default on the storage domain. To configure this, specify
+// Creation of a new <<types/storage_domain,StorageDomain>> requires the `name`, `type`, `host`, and `storage`
+// attributes. Identify the `host` attribute with the `id` or `name` attributes. In {product-name} 3.6 and
+// later you can enable the wipe after delete option by default on the storage domain. To configure this, specify
 // `wipe_after_delete` in the POST request. This option can be edited after the domain is created, but doing so will
 // not change the wipe after delete property of disks that already exist.
-// To add a new storage domain with specified `name`, `type`, `storage.type`, `storage.address` and `storage.path`
-// and by using a host with an id `123`, send a request as follows:
+// To add a new storage domain with specified `name`, `type`, `storage.type`, `storage.address`, and `storage.path`,
+// and using a host with an id `123`, send a request like this:
 // [source]
 // ----
 // POST /ovirt-engine/api/storageDomains
 // ----
-// With a request body as follows:
+// With a request body like this:
 // [source,xml]
 // ----
 // <storage_domain>
@@ -61191,6 +66318,17 @@ func (p *storageDomainsServiceAddBlockDomainRequest) Send() (*storageDomainsServ
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -61318,6 +66456,17 @@ func (p *storageDomainsServiceAddByPathRequest) Send() (*storageDomainsServiceAd
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -61363,7 +66512,7 @@ func (p *storageDomainsService) AddByPath() *storageDomainsServiceAddByPathReque
 }
 
 //
-// Add a new storage domain to the system using a direct lun.
+// Add a new storage domain to the system using a direct LUN.
 //
 type storageDomainsServiceAddDirectLunRequest struct {
 	storageDomainsService *storageDomainsService
@@ -61445,6 +66594,17 @@ func (p *storageDomainsServiceAddDirectLunRequest) Send() (*storageDomainsServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -61462,7 +66622,7 @@ func (p *storageDomainsServiceAddDirectLunRequest) MustSend() *storageDomainsSer
 }
 
 //
-// Add a new storage domain to the system using a direct lun.
+// Add a new storage domain to the system using a direct LUN.
 //
 type storageDomainsServiceAddDirectLunResponse struct {
 	storageDomain *StorageDomain
@@ -61483,14 +66643,14 @@ func (p *storageDomainsServiceAddDirectLunResponse) MustStorageDomain() *Storage
 }
 
 //
-// Add a new storage domain to the system using a direct lun.
+// Add a new storage domain to the system using a direct LUN.
 //
 func (p *storageDomainsService) AddDirectLun() *storageDomainsServiceAddDirectLunRequest {
 	return &storageDomainsServiceAddDirectLunRequest{storageDomainsService: p}
 }
 
 //
-// Add a new storage domain to the system using the gluster or posixfs storage.
+// Add a new storage domain to the system using Gluster or POSIX FS storage.
 //
 type storageDomainsServiceAddGlusterOrPostfsRequest struct {
 	storageDomainsService *storageDomainsService
@@ -61572,6 +66732,17 @@ func (p *storageDomainsServiceAddGlusterOrPostfsRequest) Send() (*storageDomains
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -61589,7 +66760,7 @@ func (p *storageDomainsServiceAddGlusterOrPostfsRequest) MustSend() *storageDoma
 }
 
 //
-// Add a new storage domain to the system using the gluster or posixfs storage.
+// Add a new storage domain to the system using Gluster or POSIX FS storage.
 //
 type storageDomainsServiceAddGlusterOrPostfsResponse struct {
 	storageDomain *StorageDomain
@@ -61610,14 +66781,14 @@ func (p *storageDomainsServiceAddGlusterOrPostfsResponse) MustStorageDomain() *S
 }
 
 //
-// Add a new storage domain to the system using the gluster or posixfs storage.
+// Add a new storage domain to the system using Gluster or POSIX FS storage.
 //
 func (p *storageDomainsService) AddGlusterOrPostfs() *storageDomainsServiceAddGlusterOrPostfsRequest {
 	return &storageDomainsServiceAddGlusterOrPostfsRequest{storageDomainsService: p}
 }
 
 //
-// Returns the list of storage domains of the system.
+// Returns the list of storage domains in the system.
 // The order of the returned list of storage domains is guaranteed only if the `sortby` clause is included
 // in the `search` parameter.
 //
@@ -61735,6 +66906,17 @@ func (p *storageDomainsServiceListRequest) Send() (*storageDomainsServiceListRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -61759,7 +66941,7 @@ func (p *storageDomainsServiceListRequest) MustSend() *storageDomainsServiceList
 }
 
 //
-// Returns the list of storage domains of the system.
+// Returns the list of storage domains in the system.
 // The order of the returned list of storage domains is guaranteed only if the `sortby` clause is included
 // in the `search` parameter.
 //
@@ -61782,7 +66964,7 @@ func (p *storageDomainsServiceListResponse) MustStorageDomains() *StorageDomainS
 }
 
 //
-// Returns the list of storage domains of the system.
+// Returns the list of storage domains in the system.
 // The order of the returned list of storage domains is guaranteed only if the `sortby` clause is included
 // in the `search` parameter.
 //
@@ -61791,7 +66973,7 @@ func (p *storageDomainsService) List() *storageDomainsServiceListRequest {
 }
 
 //
-// Add a new storage domain to the system using the storage on the localhost at the given path.
+// Add a new storage domain to the system using the storage on the local host at the given path.
 //
 type storageDomainsServiceAddLocalRequest struct {
 	storageDomainsService *storageDomainsService
@@ -61873,6 +67055,17 @@ func (p *storageDomainsServiceAddLocalRequest) Send() (*storageDomainsServiceAdd
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -61890,7 +67083,7 @@ func (p *storageDomainsServiceAddLocalRequest) MustSend() *storageDomainsService
 }
 
 //
-// Add a new storage domain to the system using the storage on the localhost at the given path.
+// Add a new storage domain to the system using the storage on the local host at the given path.
 //
 type storageDomainsServiceAddLocalResponse struct {
 	storageDomain *StorageDomain
@@ -61911,7 +67104,7 @@ func (p *storageDomainsServiceAddLocalResponse) MustStorageDomain() *StorageDoma
 }
 
 //
-// Add a new storage domain to the system using the storage on the localhost at the given path.
+// Add a new storage domain to the system using the storage on the local host at the given path.
 //
 func (p *storageDomainsService) AddLocal() *storageDomainsServiceAddLocalRequest {
 	return &storageDomainsServiceAddLocalRequest{storageDomainsService: p}
@@ -62046,6 +67239,17 @@ func (p *clusterEnabledFeaturesServiceAddRequest) Send() (*clusterEnabledFeature
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterEnabledFeaturesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterEnabledFeaturesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -62209,6 +67413,17 @@ func (p *clusterEnabledFeaturesServiceListRequest) Send() (*clusterEnabledFeatur
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterEnabledFeaturesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterEnabledFeaturesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -62405,6 +67620,17 @@ func (p *snapshotCdromServiceGetRequest) Send() (*snapshotCdromServiceGetRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotCdromService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotCdromService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -62562,6 +67788,17 @@ func (p *quotaClusterLimitsServiceAddRequest) Send() (*quotaClusterLimitsService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaClusterLimitsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaClusterLimitsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -62701,6 +67938,17 @@ func (p *quotaClusterLimitsServiceListRequest) Send() (*quotaClusterLimitsServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaClusterLimitsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaClusterLimitsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -62872,6 +68120,17 @@ func (p *fenceAgentsServiceAddRequest) Send() (*fenceAgentsServiceAddResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.fenceAgentsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.fenceAgentsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -63030,6 +68289,17 @@ func (p *fenceAgentsServiceListRequest) Send() (*fenceAgentsServiceListResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.fenceAgentsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.fenceAgentsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -63237,6 +68507,17 @@ func (p *instanceTypeWatchdogServiceGetRequest) Send() (*instanceTypeWatchdogSer
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeWatchdogService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeWatchdogService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -63365,6 +68646,17 @@ func (p *instanceTypeWatchdogServiceRemoveRequest) Send() (*instanceTypeWatchdog
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeWatchdogService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeWatchdogService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -63486,6 +68778,17 @@ func (p *instanceTypeWatchdogServiceUpdateRequest) Send() (*instanceTypeWatchdog
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeWatchdogService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeWatchdogService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -63690,6 +68993,17 @@ func (p *assignedPermissionsServiceAddRequest) Send() (*assignedPermissionsServi
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -63914,6 +69228,17 @@ func (p *assignedPermissionsServiceAddClusterPermissionRequest) Send() (*assigne
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -64041,6 +69366,17 @@ func (p *assignedPermissionsServiceAddDataCenterPermissionRequest) Send() (*assi
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -64168,6 +69504,17 @@ func (p *assignedPermissionsServiceAddGroupLevelRequest) Send() (*assignedPermis
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -64295,6 +69642,17 @@ func (p *assignedPermissionsServiceAddHostPermissionRequest) Send() (*assignedPe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -64436,6 +69794,17 @@ func (p *assignedPermissionsServiceListRequest) Send() (*assignedPermissionsServ
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -64610,6 +69979,17 @@ func (p *assignedPermissionsServiceAddStorageDomainPermissionRequest) Send() (*a
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -64737,6 +70117,17 @@ func (p *assignedPermissionsServiceAddTemplatePermissionRequest) Send() (*assign
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -64864,6 +70255,17 @@ func (p *assignedPermissionsServiceAddUserLevelRequest) Send() (*assignedPermiss
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -64991,6 +70393,17 @@ func (p *assignedPermissionsServiceAddVmPermissionRequest) Send() (*assignedPerm
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -65118,6 +70531,17 @@ func (p *assignedPermissionsServiceAddVmPoolPermissionRequest) Send() (*assigned
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedPermissionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedPermissionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -65292,6 +70716,17 @@ func (p *permitServiceGetRequest) Send() (*permitServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.permitService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.permitService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -65450,6 +70885,17 @@ func (p *permitServiceRemoveRequest) Send() (*permitServiceRemoveResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.permitService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.permitService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -65666,6 +71112,17 @@ func (p *systemServiceGetRequest) Send() (*systemServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -65947,6 +71404,17 @@ func (p *systemServiceReloadConfigurationsRequest) Send() (*systemServiceReloadC
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -66555,6 +72023,17 @@ func (p *vmWatchdogServiceGetRequest) Send() (*vmWatchdogServiceGetResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmWatchdogService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmWatchdogService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -66688,6 +72167,17 @@ func (p *vmWatchdogServiceRemoveRequest) Send() (*vmWatchdogServiceRemoveRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmWatchdogService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmWatchdogService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -66837,6 +72327,17 @@ func (p *vmWatchdogServiceUpdateRequest) Send() (*vmWatchdogServiceUpdateRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmWatchdogService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmWatchdogService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -67039,6 +72540,17 @@ func (p *unmanagedNetworksServiceListRequest) Send() (*unmanagedNetworksServiceL
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.unmanagedNetworksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.unmanagedNetworksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -67217,6 +72729,17 @@ func (p *hostNumaNodesServiceListRequest) Send() (*hostNumaNodesServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostNumaNodesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostNumaNodesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -67393,6 +72916,17 @@ func (p *filterServiceGetRequest) Send() (*filterServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.filterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.filterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -67518,6 +73052,17 @@ func (p *filterServiceRemoveRequest) Send() (*filterServiceRemoveResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.filterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.filterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -67650,6 +73195,17 @@ func (p *storageServerConnectionExtensionServiceGetRequest) Send() (*storageServ
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionExtensionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionExtensionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -67775,6 +73331,17 @@ func (p *storageServerConnectionExtensionServiceRemoveRequest) Send() (*storageS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionExtensionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionExtensionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -67908,6 +73475,17 @@ func (p *storageServerConnectionExtensionServiceUpdateRequest) Send() (*storageS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionExtensionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionExtensionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -68136,6 +73714,17 @@ func (p *dataCenterServiceGetRequest) Send() (*dataCenterServiceGetResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.dataCenterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.dataCenterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -68352,6 +73941,17 @@ func (p *dataCenterServiceRemoveRequest) Send() (*dataCenterServiceRemoveRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.dataCenterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.dataCenterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -68507,6 +74107,17 @@ func (p *dataCenterServiceUpdateRequest) Send() (*dataCenterServiceUpdateRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.dataCenterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.dataCenterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -68812,6 +74423,17 @@ func (p *clusterFeaturesServiceListRequest) Send() (*clusterFeaturesServiceListR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterFeaturesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterFeaturesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -69033,6 +74655,17 @@ func (p *externalVmImportsServiceAddRequest) Send() (*externalVmImportsServiceAd
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalVmImportsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalVmImportsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -69245,6 +74878,17 @@ func (p *hostHooksServiceListRequest) Send() (*hostHooksServiceListResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.hostHooksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.hostHooksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -69424,6 +75068,17 @@ func (p *diskSnapshotsServiceListRequest) Send() (*diskSnapshotsServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskSnapshotsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskSnapshotsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -69594,6 +75249,17 @@ func (p *instanceTypeGraphicsConsolesServiceAddRequest) Send() (*instanceTypeGra
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeGraphicsConsolesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeGraphicsConsolesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -69733,6 +75399,17 @@ func (p *instanceTypeGraphicsConsolesServiceListRequest) Send() (*instanceTypeGr
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeGraphicsConsolesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeGraphicsConsolesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -69907,6 +75584,17 @@ func (p *affinityLabelHostsServiceAddRequest) Send() (*affinityLabelHostsService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelHostsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelHostsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -70036,6 +75724,17 @@ func (p *affinityLabelHostsServiceListRequest) Send() (*affinityLabelHostsServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelHostsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelHostsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -70204,6 +75903,17 @@ func (p *storageDomainVmServiceGetRequest) Send() (*storageDomainVmServiceGetRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainVmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainVmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -70439,6 +76149,17 @@ func (p *storageDomainVmServiceImportRequest) Send() (*storageDomainVmServiceImp
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainVmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainVmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -70720,6 +76441,17 @@ func (p *storageDomainVmServiceRegisterRequest) Send() (*storageDomainVmServiceR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainVmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainVmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -70828,6 +76560,17 @@ func (p *storageDomainVmServiceRemoveRequest) Send() (*storageDomainVmServiceRem
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainVmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainVmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -71014,6 +76757,17 @@ func (p *quotaServiceGetRequest) Send() (*quotaServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -71182,6 +76936,17 @@ func (p *quotaServiceRemoveRequest) Send() (*quotaServiceRemoveResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -71333,6 +77098,17 @@ func (p *quotaServiceUpdateRequest) Send() (*quotaServiceUpdateResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotaService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotaService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -71570,6 +77346,17 @@ func (p *clusterLevelsServiceListRequest) Send() (*clusterLevelsServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterLevelsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterLevelsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -71779,6 +77566,17 @@ func (p *clusterFeatureServiceGetRequest) Send() (*clusterFeatureServiceGetRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterFeatureService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterFeatureService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -72000,6 +77798,17 @@ func (p *diskAttachmentsServiceAddRequest) Send() (*diskAttachmentsServiceAddRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskAttachmentsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskAttachmentsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -72201,6 +78010,17 @@ func (p *diskAttachmentsServiceListRequest) Send() (*diskAttachmentsServiceListR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskAttachmentsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskAttachmentsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -72336,6 +78156,17 @@ func (p *diskAttachmentsServiceAddProvidingDiskIdRequest) Send() (*diskAttachmen
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskAttachmentsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskAttachmentsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -72460,6 +78291,17 @@ func (p *diskAttachmentsServiceAddSignature1Request) Send() (*diskAttachmentsSer
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskAttachmentsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskAttachmentsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -72618,6 +78460,17 @@ func (p *affinityGroupVmServiceRemoveRequest) Send() (*affinityGroupVmServiceRem
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityGroupVmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityGroupVmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -72772,6 +78625,17 @@ func (p *attachedStorageDomainDisksServiceAddRequest) Send() (*attachedStorageDo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainDisksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainDisksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -72920,6 +78784,17 @@ func (p *attachedStorageDomainDisksServiceListRequest) Send() (*attachedStorageD
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainDisksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainDisksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -73101,6 +78976,17 @@ func (p *permitsServiceAddRequest) Send() (*permitsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.permitsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.permitsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -73281,6 +79167,17 @@ func (p *permitsServiceListRequest) Send() (*permitsServiceListResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.permitsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.permitsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -73488,6 +79385,17 @@ func (p *vnicProfileServiceGetRequest) Send() (*vnicProfileServiceGetResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vnicProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vnicProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -73616,6 +79524,17 @@ func (p *vnicProfileServiceRemoveRequest) Send() (*vnicProfileServiceRemoveRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vnicProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vnicProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -73737,6 +79656,17 @@ func (p *vnicProfileServiceUpdateRequest) Send() (*vnicProfileServiceUpdateRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vnicProfileService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vnicProfileService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -73907,6 +79837,17 @@ func (p *templateWatchdogsServiceAddRequest) Send() (*templateWatchdogsServiceAd
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateWatchdogsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateWatchdogsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -74046,6 +79987,17 @@ func (p *templateWatchdogsServiceListRequest) Send() (*templateWatchdogsServiceL
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateWatchdogsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateWatchdogsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -74235,6 +80187,17 @@ func (p *vmApplicationsServiceListRequest) Send() (*vmApplicationsServiceListRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmApplicationsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmApplicationsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -74406,6 +80369,17 @@ func (p *templateDiskAttachmentsServiceListRequest) Send() (*templateDiskAttachm
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateDiskAttachmentsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateDiskAttachmentsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -74574,6 +80548,17 @@ func (p *instanceTypeGraphicsConsoleServiceGetRequest) Send() (*instanceTypeGrap
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeGraphicsConsoleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeGraphicsConsoleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -74702,6 +80687,17 @@ func (p *instanceTypeGraphicsConsoleServiceRemoveRequest) Send() (*instanceTypeG
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeGraphicsConsoleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeGraphicsConsoleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -74909,6 +80905,17 @@ func (p *diskServiceCopyRequest) Send() (*diskServiceCopyResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -75090,6 +81097,17 @@ func (p *diskServiceExportRequest) Send() (*diskServiceExportResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -75125,6 +81143,7 @@ type diskServiceGetRequest struct {
 	diskService *diskService
 	header      map[string]string
 	query       map[string]string
+	allContent  *bool
 	follow      *string
 }
 
@@ -75144,6 +81163,11 @@ func (p *diskServiceGetRequest) Query(key, value string) *diskServiceGetRequest 
 	return p
 }
 
+func (p *diskServiceGetRequest) AllContent(allContent bool) *diskServiceGetRequest {
+	p.allContent = &allContent
+	return p
+}
+
 func (p *diskServiceGetRequest) Follow(follow string) *diskServiceGetRequest {
 	p.follow = &follow
 	return p
@@ -75152,6 +81176,10 @@ func (p *diskServiceGetRequest) Follow(follow string) *diskServiceGetRequest {
 func (p *diskServiceGetRequest) Send() (*diskServiceGetResponse, error) {
 	rawURL := fmt.Sprintf("%s%s", p.diskService.connection.URL(), p.diskService.path)
 	values := make(url.Values)
+	if p.allContent != nil {
+		values["all_content"] = []string{fmt.Sprintf("%v", *p.allContent)}
+	}
+
 	if p.follow != nil {
 		values["follow"] = []string{fmt.Sprintf("%v", *p.follow)}
 	}
@@ -75195,6 +81223,17 @@ func (p *diskServiceGetRequest) Send() (*diskServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -75389,6 +81428,17 @@ func (p *diskServiceMoveRequest) Send() (*diskServiceMoveResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -75471,6 +81521,139 @@ type diskServiceMoveResponse struct {
 //
 func (p *diskService) Move() *diskServiceMoveRequest {
 	return &diskServiceMoveRequest{diskService: p}
+}
+
+//
+// Reduces the size of the disk image.
+// Invokes _reduce_ on the logical volume (i.e. this is only applicable for block storage domains).
+// This is applicable for floating disks and disks attached to non-running virtual machines.
+// There is no need to specify the size as the optimal size is calculated automatically.
+//
+type diskServiceReduceRequest struct {
+	diskService *diskService
+	header      map[string]string
+	query       map[string]string
+	async       *bool
+}
+
+func (p *diskServiceReduceRequest) Header(key, value string) *diskServiceReduceRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *diskServiceReduceRequest) Query(key, value string) *diskServiceReduceRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *diskServiceReduceRequest) Async(async bool) *diskServiceReduceRequest {
+	p.async = &async
+	return p
+}
+
+func (p *diskServiceReduceRequest) Send() (*diskServiceReduceResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/reduce", p.diskService.connection.URL(), p.diskService.path)
+	actionBuilder := NewActionBuilder()
+	if p.async != nil {
+		actionBuilder.Async(*p.async)
+	}
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.diskService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.diskService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.diskService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.diskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	_, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	return new(diskServiceReduceResponse), nil
+}
+
+func (p *diskServiceReduceRequest) MustSend() *diskServiceReduceResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Reduces the size of the disk image.
+// Invokes _reduce_ on the logical volume (i.e. this is only applicable for block storage domains).
+// This is applicable for floating disks and disks attached to non-running virtual machines.
+// There is no need to specify the size as the optimal size is calculated automatically.
+//
+type diskServiceReduceResponse struct {
+}
+
+//
+// Reduces the size of the disk image.
+// Invokes _reduce_ on the logical volume (i.e. this is only applicable for block storage domains).
+// This is applicable for floating disks and disks attached to non-running virtual machines.
+// There is no need to specify the size as the optimal size is calculated automatically.
+//
+func (p *diskService) Reduce() *diskServiceReduceRequest {
+	return &diskServiceReduceRequest{diskService: p}
 }
 
 //
@@ -75572,6 +81755,17 @@ func (p *diskServiceRefreshLunRequest) Send() (*diskServiceRefreshLunResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -75709,6 +81903,17 @@ func (p *diskServiceRemoveRequest) Send() (*diskServiceRemoveResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -75820,6 +82025,17 @@ func (p *diskServiceSparsifyRequest) Send() (*diskServiceSparsifyResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -75951,6 +82167,17 @@ func (p *diskServiceUpdateRequest) Send() (*diskServiceUpdateResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -76160,6 +82387,17 @@ func (p *vmNumaNodeServiceGetRequest) Send() (*vmNumaNodeServiceGetResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNumaNodeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNumaNodeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -76216,6 +82454,8 @@ func (p *vmNumaNodeService) Get() *vmNumaNodeServiceGetRequest {
 // ----
 // DELETE /ovirt-engine/api/vms/123/numanodes/456
 // ----
+// NOTE: It's required to remove the numa nodes from the highest index
+// first.
 //
 type vmNumaNodeServiceRemoveRequest struct {
 	vmNumaNodeService *vmNumaNodeService
@@ -76291,6 +82531,17 @@ func (p *vmNumaNodeServiceRemoveRequest) Send() (*vmNumaNodeServiceRemoveRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNumaNodeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNumaNodeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -76316,6 +82567,8 @@ func (p *vmNumaNodeServiceRemoveRequest) MustSend() *vmNumaNodeServiceRemoveResp
 // ----
 // DELETE /ovirt-engine/api/vms/123/numanodes/456
 // ----
+// NOTE: It's required to remove the numa nodes from the highest index
+// first.
 //
 type vmNumaNodeServiceRemoveResponse struct {
 }
@@ -76327,6 +82580,8 @@ type vmNumaNodeServiceRemoveResponse struct {
 // ----
 // DELETE /ovirt-engine/api/vms/123/numanodes/456
 // ----
+// NOTE: It's required to remove the numa nodes from the highest index
+// first.
 //
 func (p *vmNumaNodeService) Remove() *vmNumaNodeServiceRemoveRequest {
 	return &vmNumaNodeServiceRemoveRequest{vmNumaNodeService: p}
@@ -76438,6 +82693,17 @@ func (p *vmNumaNodeServiceUpdateRequest) Send() (*vmNumaNodeServiceUpdateRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNumaNodeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNumaNodeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -76635,6 +82901,17 @@ func (p *affinityGroupServiceGetRequest) Send() (*affinityGroupServiceGetRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityGroupService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityGroupService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -76785,6 +83062,17 @@ func (p *affinityGroupServiceRemoveRequest) Send() (*affinityGroupServiceRemoveR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityGroupService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityGroupService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -76914,6 +83202,17 @@ func (p *affinityGroupServiceUpdateRequest) Send() (*affinityGroupServiceUpdateR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityGroupService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityGroupService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -77100,6 +83399,17 @@ func (p *quotasServiceAddRequest) Send() (*quotasServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotasService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotasService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -77263,6 +83573,17 @@ func (p *quotasServiceListRequest) Send() (*quotasServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.quotasService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.quotasService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -77463,6 +83784,17 @@ func (p *storageDomainContentDisksServiceListRequest) Send() (*storageDomainCont
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainContentDisksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainContentDisksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -77646,6 +83978,17 @@ func (p *networkFilterServiceGetRequest) Send() (*networkFilterServiceGetRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networkFilterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networkFilterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -77814,6 +84157,17 @@ func (p *iconServiceGetRequest) Send() (*iconServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.iconService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.iconService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -78004,6 +84358,17 @@ func (p *templateDisksServiceListRequest) Send() (*templateDisksServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateDisksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateDisksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -78183,6 +84548,17 @@ func (p *imagesServiceListRequest) Send() (*imagesServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imagesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imagesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -78371,6 +84747,17 @@ func (p *storageDomainDiskServiceCopyRequest) Send() (*storageDomainDiskServiceC
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -78491,6 +84878,17 @@ func (p *storageDomainDiskServiceExportRequest) Send() (*storageDomainDiskServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -78602,6 +85000,17 @@ func (p *storageDomainDiskServiceGetRequest) Send() (*storageDomainDiskServiceGe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -78757,6 +85166,17 @@ func (p *storageDomainDiskServiceMoveRequest) Send() (*storageDomainDiskServiceM
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -78789,6 +85209,139 @@ type storageDomainDiskServiceMoveResponse struct {
 //
 func (p *storageDomainDiskService) Move() *storageDomainDiskServiceMoveRequest {
 	return &storageDomainDiskServiceMoveRequest{storageDomainDiskService: p}
+}
+
+//
+// Reduces the size of the disk image.
+// Invokes _reduce_ on the logical volume (i.e. this is only applicable for block storage domains).
+// This is applicable for floating disks and disks attached to non-running virtual machines.
+// There is no need to specify the size as the optimal size is calculated automatically.
+//
+type storageDomainDiskServiceReduceRequest struct {
+	storageDomainDiskService *storageDomainDiskService
+	header                   map[string]string
+	query                    map[string]string
+	async                    *bool
+}
+
+func (p *storageDomainDiskServiceReduceRequest) Header(key, value string) *storageDomainDiskServiceReduceRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *storageDomainDiskServiceReduceRequest) Query(key, value string) *storageDomainDiskServiceReduceRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *storageDomainDiskServiceReduceRequest) Async(async bool) *storageDomainDiskServiceReduceRequest {
+	p.async = &async
+	return p
+}
+
+func (p *storageDomainDiskServiceReduceRequest) Send() (*storageDomainDiskServiceReduceResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/reduce", p.storageDomainDiskService.connection.URL(), p.storageDomainDiskService.path)
+	actionBuilder := NewActionBuilder()
+	if p.async != nil {
+		actionBuilder.Async(*p.async)
+	}
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.storageDomainDiskService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.storageDomainDiskService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.storageDomainDiskService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.storageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	_, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	return new(storageDomainDiskServiceReduceResponse), nil
+}
+
+func (p *storageDomainDiskServiceReduceRequest) MustSend() *storageDomainDiskServiceReduceResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Reduces the size of the disk image.
+// Invokes _reduce_ on the logical volume (i.e. this is only applicable for block storage domains).
+// This is applicable for floating disks and disks attached to non-running virtual machines.
+// There is no need to specify the size as the optimal size is calculated automatically.
+//
+type storageDomainDiskServiceReduceResponse struct {
+}
+
+//
+// Reduces the size of the disk image.
+// Invokes _reduce_ on the logical volume (i.e. this is only applicable for block storage domains).
+// This is applicable for floating disks and disks attached to non-running virtual machines.
+// There is no need to specify the size as the optimal size is calculated automatically.
+//
+func (p *storageDomainDiskService) Reduce() *storageDomainDiskServiceReduceRequest {
+	return &storageDomainDiskServiceReduceRequest{storageDomainDiskService: p}
 }
 
 //
@@ -78861,6 +85414,17 @@ func (p *storageDomainDiskServiceRemoveRequest) Send() (*storageDomainDiskServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -78977,6 +85541,17 @@ func (p *storageDomainDiskServiceSparsifyRequest) Send() (*storageDomainDiskServ
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -79094,6 +85669,17 @@ func (p *storageDomainDiskServiceUpdateRequest) Send() (*storageDomainDiskServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -79292,6 +85878,17 @@ func (p *assignedRolesServiceListRequest) Send() (*assignedRolesServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedRolesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedRolesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -79479,6 +86076,17 @@ func (p *vmPoolServiceAllocateVmRequest) Send() (*vmPoolServiceAllocateVmRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmPoolService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmPoolService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -79638,6 +86246,17 @@ func (p *vmPoolServiceGetRequest) Send() (*vmPoolServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmPoolService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmPoolService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -79818,6 +86437,17 @@ func (p *vmPoolServiceRemoveRequest) Send() (*vmPoolServiceRemoveResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmPoolService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmPoolService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -79964,6 +86594,17 @@ func (p *vmPoolServiceUpdateRequest) Send() (*vmPoolServiceUpdateResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmPoolService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmPoolService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -80185,6 +86826,17 @@ func (p *storageServerConnectionExtensionsServiceAddRequest) Send() (*storageSer
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionExtensionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionExtensionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -80356,6 +87008,17 @@ func (p *storageServerConnectionExtensionsServiceListRequest) Send() (*storageSe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageServerConnectionExtensionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageServerConnectionExtensionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -80525,6 +87188,17 @@ func (p *virtualFunctionAllowedNetworksServiceAddRequest) Send() (*virtualFuncti
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.virtualFunctionAllowedNetworksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.virtualFunctionAllowedNetworksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -80662,6 +87336,17 @@ func (p *virtualFunctionAllowedNetworksServiceListRequest) Send() (*virtualFunct
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.virtualFunctionAllowedNetworksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.virtualFunctionAllowedNetworksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -80832,6 +87517,17 @@ func (p *cpuProfilesServiceAddRequest) Send() (*cpuProfilesServiceAddResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.cpuProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.cpuProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -80971,6 +87667,17 @@ func (p *cpuProfilesServiceListRequest) Send() (*cpuProfilesServiceListResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.cpuProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.cpuProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -81150,6 +87857,17 @@ func (p *templateCdromsServiceListRequest) Send() (*templateCdromsServiceListRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateCdromsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateCdromsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -81336,6 +88054,17 @@ func (p *fenceAgentServiceGetRequest) Send() (*fenceAgentServiceGetResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.fenceAgentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.fenceAgentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -81502,6 +88231,17 @@ func (p *fenceAgentServiceRemoveRequest) Send() (*fenceAgentServiceRemoveRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.fenceAgentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.fenceAgentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -81631,6 +88371,17 @@ func (p *fenceAgentServiceUpdateRequest) Send() (*fenceAgentServiceUpdateRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.fenceAgentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.fenceAgentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -81785,6 +88536,17 @@ func (p *snapshotNicServiceGetRequest) Send() (*snapshotNicServiceGetResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.snapshotNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.snapshotNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -81954,6 +88716,17 @@ func (p *diskAttachmentServiceGetRequest) Send() (*diskAttachmentServiceGetRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskAttachmentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskAttachmentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -82119,6 +88892,17 @@ func (p *diskAttachmentServiceRemoveRequest) Send() (*diskAttachmentServiceRemov
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskAttachmentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskAttachmentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -82258,6 +89042,17 @@ func (p *diskAttachmentServiceUpdateRequest) Send() (*diskAttachmentServiceUpdat
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.diskAttachmentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.diskAttachmentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -82444,6 +89239,17 @@ func (p *affinityLabelVmServiceGetRequest) Send() (*affinityLabelVmServiceGetRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelVmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelVmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -82562,6 +89368,17 @@ func (p *affinityLabelVmServiceRemoveRequest) Send() (*affinityLabelVmServiceRem
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityLabelVmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityLabelVmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -82726,6 +89543,17 @@ func (p *clusterLevelServiceGetRequest) Send() (*clusterLevelServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterLevelService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterLevelService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -82951,6 +89779,17 @@ func (p *instanceTypeNicsServiceAddRequest) Send() (*instanceTypeNicsServiceAddR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeNicsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeNicsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -83100,6 +89939,17 @@ func (p *instanceTypeNicsServiceListRequest) Send() (*instanceTypeNicsServiceLis
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeNicsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeNicsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -83300,6 +90150,17 @@ func (p *eventsServiceAddRequest) Send() (*eventsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.eventsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.eventsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -83568,6 +90429,17 @@ func (p *eventsServiceListRequest) Send() (*eventsServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.eventsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.eventsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -83787,6 +90659,17 @@ func (p *eventsServiceUndeleteRequest) Send() (*eventsServiceUndeleteResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.eventsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.eventsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -83975,6 +90858,17 @@ func (p *networksServiceAddRequest) Send() (*networksServiceAddResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -84240,6 +91134,17 @@ func (p *networksServiceListRequest) Send() (*networksServiceListResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.networksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.networksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -84479,6 +91384,17 @@ func (p *jobServiceClearRequest) Send() (*jobServiceClearResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.jobService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.jobService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -84643,6 +91559,17 @@ func (p *jobServiceEndRequest) Send() (*jobServiceEndResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.jobService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.jobService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -84797,6 +91724,17 @@ func (p *jobServiceGetRequest) Send() (*jobServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.jobService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.jobService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -85053,6 +91991,17 @@ func (p *systemOptionServiceGetRequest) Send() (*systemOptionServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.systemOptionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.systemOptionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -85212,6 +92161,7 @@ func NewStorageDomainService(connection *Connection, path string) *storageDomain
 }
 
 //
+// Retrieves the description of the storage domain.
 //
 type storageDomainServiceGetRequest struct {
 	storageDomainService *storageDomainService
@@ -85297,6 +92247,17 @@ func (p *storageDomainServiceGetRequest) Send() (*storageDomainServiceGetRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -85321,6 +92282,7 @@ func (p *storageDomainServiceGetRequest) MustSend() *storageDomainServiceGetResp
 }
 
 //
+// Retrieves the description of the storage domain.
 //
 type storageDomainServiceGetResponse struct {
 	storageDomain *StorageDomain
@@ -85341,6 +92303,7 @@ func (p *storageDomainServiceGetResponse) MustStorageDomain() *StorageDomain {
 }
 
 //
+// Retrieves the description of the storage domain.
 //
 func (p *storageDomainService) Get() *storageDomainServiceGetRequest {
 	return &storageDomainServiceGetRequest{storageDomainService: p}
@@ -85440,6 +92403,17 @@ func (p *storageDomainServiceIsAttachedRequest) Send() (*storageDomainServiceIsA
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -85599,6 +92573,17 @@ func (p *storageDomainServiceReduceLunsRequest) Send() (*storageDomainServiceRed
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -85784,6 +92769,17 @@ func (p *storageDomainServiceRefreshLunsRequest) Send() (*storageDomainServiceRe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -85964,6 +92960,17 @@ func (p *storageDomainServiceRemoveRequest) Send() (*storageDomainServiceRemoveR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -86117,6 +93124,17 @@ func (p *storageDomainServiceUpdateRequest) Send() (*storageDomainServiceUpdateR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -86301,6 +93319,17 @@ func (p *storageDomainServiceUpdateOvfStoreRequest) Send() (*storageDomainServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -86571,6 +93600,17 @@ func (p *assignedVnicProfilesServiceAddRequest) Send() (*assignedVnicProfilesSer
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedVnicProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedVnicProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -86710,6 +93750,17 @@ func (p *assignedVnicProfilesServiceListRequest) Send() (*assignedVnicProfilesSe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedVnicProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedVnicProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -86793,16 +93844,31 @@ func (op *assignedVnicProfilesService) String() string {
 // of the <<services/image_transfers>> service, stating the image to transfer
 // data to/from.
 // After doing that, the transfer is managed by this service.
-// E.g., for uploading/downloading a disk with id `52cb593f-837c-4633-a444-35a0a0383706`:
 // *Using oVirt's Python's SDK:*
+// Uploading a `disk` with id `123` (on a random host in the data center):
 // [source,python]
 // ----
 // transfers_service = system_service.image_transfers_service()
 // transfer = transfers_service.add(
 //    types.ImageTransfer(
-//       image=types.Image(
-//          id='52cb593f-837c-4633-a444-35a0a0383706'
+//       disk=types.Disk(
+//          id='123'
 //       )
+//    )
+// )
+// ----
+// Uploading a `disk` with id `123` on `host` id `456`:
+// [source,python]
+// ----
+// transfers_service = system_service.image_transfers_service()
+// transfer = transfers_service.add(
+//    types.ImageTransfer(
+//       disk=types.Disk(
+//          id='123'
+//       ),
+//       host=types.Host(
+//          id='456'
+//      )
 //    )
 // )
 // ----
@@ -86815,8 +93881,8 @@ func (op *assignedVnicProfilesService) String() string {
 // transfers_service = system_service.image_transfers_service()
 // transfer = transfers_service.add(
 //    types.ImageTransfer(
-//       image=types.Image(
-//          id='52cb593f-837c-4633-a444-35a0a0383706'
+//       disk=types.Disk(
+//          id='123'
 //       ),
 //       direction=types.ImageTransferDirection.DOWNLOAD
 //    )
@@ -87017,6 +94083,121 @@ func NewImageTransferService(connection *Connection, path string) *imageTransfer
 }
 
 //
+// Cancel the image transfer session. This terminates the transfer operation and removes the partial image.
+//
+type imageTransferServiceCancelRequest struct {
+	imageTransferService *imageTransferService
+	header               map[string]string
+	query                map[string]string
+}
+
+func (p *imageTransferServiceCancelRequest) Header(key, value string) *imageTransferServiceCancelRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *imageTransferServiceCancelRequest) Query(key, value string) *imageTransferServiceCancelRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *imageTransferServiceCancelRequest) Send() (*imageTransferServiceCancelResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/cancel", p.imageTransferService.connection.URL(), p.imageTransferService.path)
+	actionBuilder := NewActionBuilder()
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.imageTransferService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.imageTransferService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.imageTransferService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.imageTransferService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransferService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	_, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	return new(imageTransferServiceCancelResponse), nil
+}
+
+func (p *imageTransferServiceCancelRequest) MustSend() *imageTransferServiceCancelResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Cancel the image transfer session. This terminates the transfer operation and removes the partial image.
+//
+type imageTransferServiceCancelResponse struct {
+}
+
+//
+// Cancel the image transfer session. This terminates the transfer operation and removes the partial image.
+//
+func (p *imageTransferService) Cancel() *imageTransferServiceCancelRequest {
+	return &imageTransferServiceCancelRequest{imageTransferService: p}
+}
+
+//
 // Extend the image transfer session.
 //
 type imageTransferServiceExtendRequest struct {
@@ -87092,6 +94273,17 @@ func (p *imageTransferServiceExtendRequest) Send() (*imageTransferServiceExtendR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageTransferService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransferService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -87200,6 +94392,17 @@ func (p *imageTransferServiceFinalizeRequest) Send() (*imageTransferServiceFinal
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageTransferService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransferService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -87313,6 +94516,17 @@ func (p *imageTransferServiceGetRequest) Send() (*imageTransferServiceGetRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageTransferService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransferService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -87440,6 +94654,17 @@ func (p *imageTransferServicePauseRequest) Send() (*imageTransferServicePauseRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageTransferService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransferService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -87554,6 +94779,17 @@ func (p *imageTransferServiceResumeRequest) Send() (*imageTransferServiceResumeR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.imageTransferService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.imageTransferService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -87721,6 +94957,17 @@ func (p *roleServiceGetRequest) Send() (*roleServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.roleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.roleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -87884,6 +95131,17 @@ func (p *roleServiceRemoveRequest) Send() (*roleServiceRemoveResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.roleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.roleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -88031,6 +95289,17 @@ func (p *roleServiceUpdateRequest) Send() (*roleServiceUpdateResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.roleService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.roleService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -88238,6 +95507,17 @@ func (p *vmNicServiceActivateRequest) Send() (*vmNicServiceActivateResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -88348,6 +95628,17 @@ func (p *vmNicServiceDeactivateRequest) Send() (*vmNicServiceDeactivateResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -88450,6 +95741,17 @@ func (p *vmNicServiceGetRequest) Send() (*vmNicServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -88590,6 +95892,17 @@ func (p *vmNicServiceRemoveRequest) Send() (*vmNicServiceRemoveResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -88763,6 +96076,17 @@ func (p *vmNicServiceUpdateRequest) Send() (*vmNicServiceUpdateResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNicService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNicService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -89003,6 +96327,17 @@ func (p *operatingSystemServiceGetRequest) Send() (*operatingSystemServiceGetRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.operatingSystemService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.operatingSystemService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -89160,6 +96495,17 @@ func (p *attachedStorageDomainsServiceAddRequest) Send() (*attachedStorageDomain
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -89299,6 +96645,17 @@ func (p *attachedStorageDomainsServiceListRequest) Send() (*attachedStorageDomai
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -89481,6 +96838,17 @@ func (p *externalProviderServiceImportCertificatesRequest) Send() (*externalProv
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -89599,6 +96967,17 @@ func (p *externalProviderServiceTestConnectivityRequest) Send() (*externalProvid
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -89765,6 +97144,17 @@ func (p *vmApplicationServiceGetRequest) Send() (*vmApplicationServiceGetRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmApplicationService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmApplicationService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -89923,6 +97313,17 @@ func (p *weightsServiceAddRequest) Send() (*weightsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.weightsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.weightsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -90072,6 +97473,17 @@ func (p *weightsServiceListRequest) Send() (*weightsServiceListResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.weightsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.weightsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -90298,6 +97710,17 @@ func (p *statisticsServiceListRequest) Send() (*statisticsServiceListResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.statisticsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.statisticsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -90584,6 +98007,17 @@ func (p *affinityGroupsServiceAddRequest) Send() (*affinityGroupsServiceAddRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityGroupsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityGroupsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -90761,6 +98195,17 @@ func (p *affinityGroupsServiceListRequest) Send() (*affinityGroupsServiceListRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.affinityGroupsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.affinityGroupsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -90943,6 +98388,17 @@ func (p *assignedTagServiceGetRequest) Send() (*assignedTagServiceGetResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedTagService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedTagService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -91101,6 +98557,17 @@ func (p *assignedTagServiceRemoveRequest) Send() (*assignedTagServiceRemoveRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedTagService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedTagService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -91263,6 +98730,17 @@ func (p *attachedStorageDomainServiceActivateRequest) Send() (*attachedStorageDo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -91421,6 +98899,17 @@ func (p *attachedStorageDomainServiceDeactivateRequest) Send() (*attachedStorage
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -91553,6 +99042,17 @@ func (p *attachedStorageDomainServiceGetRequest) Send() (*attachedStorageDomainS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -91678,6 +99178,17 @@ func (p *attachedStorageDomainServiceRemoveRequest) Send() (*attachedStorageDoma
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.attachedStorageDomainService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.attachedStorageDomainService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -91862,6 +99373,17 @@ func (p *katelloErrataServiceListRequest) Send() (*katelloErrataServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.katelloErrataService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.katelloErrataService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -92116,6 +99638,17 @@ func (p *externalHostGroupsServiceListRequest) Send() (*externalHostGroupsServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostGroupsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostGroupsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -92350,6 +99883,17 @@ func (p *katelloErratumServiceGetRequest) Send() (*katelloErratumServiceGetRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.katelloErratumService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.katelloErratumService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -92591,6 +100135,17 @@ func (p *externalDiscoveredHostsServiceListRequest) Send() (*externalDiscoveredH
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalDiscoveredHostsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalDiscoveredHostsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -92833,6 +100388,17 @@ func (p *externalHostGroupServiceGetRequest) Send() (*externalHostGroupServiceGe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostGroupService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostGroupService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -92944,7 +100510,7 @@ func NewExternalHostProvidersService(connection *Connection, path string) *exter
 }
 
 //
-// Add a new external host provider to the system.
+// Adds a new external host provider to the system.
 //
 type externalHostProvidersServiceAddRequest struct {
 	externalHostProvidersService *externalHostProvidersService
@@ -93023,6 +100589,17 @@ func (p *externalHostProvidersServiceAddRequest) Send() (*externalHostProvidersS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostProvidersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostProvidersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -93047,7 +100624,7 @@ func (p *externalHostProvidersServiceAddRequest) MustSend() *externalHostProvide
 }
 
 //
-// Add a new external host provider to the system.
+// Adds a new external host provider to the system.
 //
 type externalHostProvidersServiceAddResponse struct {
 	provider *ExternalHostProvider
@@ -93068,7 +100645,7 @@ func (p *externalHostProvidersServiceAddResponse) MustProvider() *ExternalHostPr
 }
 
 //
-// Add a new external host provider to the system.
+// Adds a new external host provider to the system.
 //
 func (p *externalHostProvidersService) Add() *externalHostProvidersServiceAddRequest {
 	return &externalHostProvidersServiceAddRequest{externalHostProvidersService: p}
@@ -93076,7 +100653,7 @@ func (p *externalHostProvidersService) Add() *externalHostProvidersServiceAddReq
 
 //
 // Returns the list of external host providers.
-// The order of the returned list of host providers isn't guaranteed.
+// The order of the returned list of host providers is not guaranteed.
 //
 type externalHostProvidersServiceListRequest struct {
 	externalHostProvidersService *externalHostProvidersService
@@ -93084,6 +100661,7 @@ type externalHostProvidersServiceListRequest struct {
 	query                        map[string]string
 	follow                       *string
 	max                          *int64
+	search                       *string
 }
 
 func (p *externalHostProvidersServiceListRequest) Header(key, value string) *externalHostProvidersServiceListRequest {
@@ -93112,6 +100690,11 @@ func (p *externalHostProvidersServiceListRequest) Max(max int64) *externalHostPr
 	return p
 }
 
+func (p *externalHostProvidersServiceListRequest) Search(search string) *externalHostProvidersServiceListRequest {
+	p.search = &search
+	return p
+}
+
 func (p *externalHostProvidersServiceListRequest) Send() (*externalHostProvidersServiceListResponse, error) {
 	rawURL := fmt.Sprintf("%s%s", p.externalHostProvidersService.connection.URL(), p.externalHostProvidersService.path)
 	values := make(url.Values)
@@ -93121,6 +100704,10 @@ func (p *externalHostProvidersServiceListRequest) Send() (*externalHostProviders
 
 	if p.max != nil {
 		values["max"] = []string{fmt.Sprintf("%v", *p.max)}
+	}
+
+	if p.search != nil {
+		values["search"] = []string{fmt.Sprintf("%v", *p.search)}
 	}
 
 	if p.query != nil {
@@ -93162,6 +100749,17 @@ func (p *externalHostProvidersServiceListRequest) Send() (*externalHostProviders
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostProvidersService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostProvidersService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -93187,7 +100785,7 @@ func (p *externalHostProvidersServiceListRequest) MustSend() *externalHostProvid
 
 //
 // Returns the list of external host providers.
-// The order of the returned list of host providers isn't guaranteed.
+// The order of the returned list of host providers is not guaranteed.
 //
 type externalHostProvidersServiceListResponse struct {
 	providers *ExternalHostProviderSlice
@@ -93209,7 +100807,7 @@ func (p *externalHostProvidersServiceListResponse) MustProviders() *ExternalHost
 
 //
 // Returns the list of external host providers.
-// The order of the returned list of host providers isn't guaranteed.
+// The order of the returned list of host providers is not guaranteed.
 //
 func (p *externalHostProvidersService) List() *externalHostProvidersServiceListRequest {
 	return &externalHostProvidersServiceListRequest{externalHostProvidersService: p}
@@ -93348,6 +100946,17 @@ func (p *externalComputeResourceServiceGetRequest) Send() (*externalComputeResou
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalComputeResourceService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalComputeResourceService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -93566,6 +101175,17 @@ func (p *externalComputeResourcesServiceListRequest) Send() (*externalComputeRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalComputeResourcesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalComputeResourcesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -93769,6 +101389,17 @@ func (p *externalHostServiceGetRequest) Send() (*externalHostServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -93941,6 +101572,17 @@ func (p *externalDiscoveredHostServiceGetRequest) Send() (*externalDiscoveredHos
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalDiscoveredHostService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalDiscoveredHostService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -94151,6 +101793,17 @@ func (p *externalHostProviderServiceGetRequest) Send() (*externalHostProviderSer
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -94325,6 +101978,17 @@ func (p *externalHostProviderServiceImportCertificatesRequest) Send() (*external
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -94429,6 +102093,17 @@ func (p *externalHostProviderServiceRemoveRequest) Send() (*externalHostProvider
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -94548,6 +102223,17 @@ func (p *externalHostProviderServiceTestConnectivityRequest) Send() (*externalHo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -94676,6 +102362,17 @@ func (p *externalHostProviderServiceUpdateRequest) Send() (*externalHostProvider
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostProviderService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostProviderService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -94931,6 +102628,17 @@ func (p *engineKatelloErrataServiceListRequest) Send() (*engineKatelloErrataServ
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.engineKatelloErrataService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.engineKatelloErrataService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -95163,6 +102871,17 @@ func (p *externalHostsServiceListRequest) Send() (*externalHostsServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalHostsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalHostsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -95332,6 +103051,17 @@ func (p *storageDomainVmDiskAttachmentsServiceListRequest) Send() (*storageDomai
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainVmDiskAttachmentsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainVmDiskAttachmentsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -95501,6 +103231,17 @@ func (p *nicNetworkFilterParameterServiceGetRequest) Send() (*nicNetworkFilterPa
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.nicNetworkFilterParameterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.nicNetworkFilterParameterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -95625,6 +103366,17 @@ func (p *nicNetworkFilterParameterServiceRemoveRequest) Send() (*nicNetworkFilte
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.nicNetworkFilterParameterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.nicNetworkFilterParameterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -95762,6 +103514,17 @@ func (p *nicNetworkFilterParameterServiceUpdateRequest) Send() (*nicNetworkFilte
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.nicNetworkFilterParameterService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.nicNetworkFilterParameterService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -95944,6 +103707,17 @@ func (p *vmSessionServiceGetRequest) Send() (*vmSessionServiceGetResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmSessionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmSessionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -96121,6 +103895,17 @@ func (p *templateDiskServiceCopyRequest) Send() (*templateDiskServiceCopyRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -96249,6 +104034,17 @@ func (p *templateDiskServiceExportRequest) Send() (*templateDiskServiceExportRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -96351,6 +104147,17 @@ func (p *templateDiskServiceGetRequest) Send() (*templateDiskServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -96476,6 +104283,17 @@ func (p *templateDiskServiceRemoveRequest) Send() (*templateDiskServiceRemoveRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -96729,6 +104547,17 @@ func (p *templatesServiceAddRequest) Send() (*templatesServiceAddResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templatesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templatesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -96973,6 +104802,318 @@ func (p *templatesService) Add() *templatesServiceAddRequest {
 }
 
 //
+// Add a virtual machine template to the system from a configuration. Requires the configuration type, the configuration data, and the target cluster.
+//
+type templatesServiceAddFromConfigurationRequest struct {
+	templatesService *templatesService
+	header           map[string]string
+	query            map[string]string
+	clonePermissions *bool
+	seal             *bool
+	template         *Template
+}
+
+func (p *templatesServiceAddFromConfigurationRequest) Header(key, value string) *templatesServiceAddFromConfigurationRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *templatesServiceAddFromConfigurationRequest) Query(key, value string) *templatesServiceAddFromConfigurationRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *templatesServiceAddFromConfigurationRequest) ClonePermissions(clonePermissions bool) *templatesServiceAddFromConfigurationRequest {
+	p.clonePermissions = &clonePermissions
+	return p
+}
+
+func (p *templatesServiceAddFromConfigurationRequest) Seal(seal bool) *templatesServiceAddFromConfigurationRequest {
+	p.seal = &seal
+	return p
+}
+
+func (p *templatesServiceAddFromConfigurationRequest) Template(template *Template) *templatesServiceAddFromConfigurationRequest {
+	p.template = template
+	return p
+}
+
+func (p *templatesServiceAddFromConfigurationRequest) Send() (*templatesServiceAddFromConfigurationResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/fromconfiguration", p.templatesService.connection.URL(), p.templatesService.path)
+	actionBuilder := NewActionBuilder()
+	if p.clonePermissions != nil {
+		actionBuilder.ClonePermissions(*p.clonePermissions)
+	}
+	if p.seal != nil {
+		actionBuilder.Seal(*p.seal)
+	}
+	actionBuilder.Template(p.template)
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.templatesService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.templatesService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.templatesService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.templatesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templatesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	action, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	result := action.MustTemplate()
+	return &templatesServiceAddFromConfigurationResponse{template: result}, nil
+}
+
+func (p *templatesServiceAddFromConfigurationRequest) MustSend() *templatesServiceAddFromConfigurationResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Add a virtual machine template to the system from a configuration. Requires the configuration type, the configuration data, and the target cluster.
+//
+type templatesServiceAddFromConfigurationResponse struct {
+	template *Template
+}
+
+func (p *templatesServiceAddFromConfigurationResponse) Template() (*Template, bool) {
+	if p.template != nil {
+		return p.template, true
+	}
+	return nil, false
+}
+
+func (p *templatesServiceAddFromConfigurationResponse) MustTemplate() *Template {
+	if p.template == nil {
+		panic("template in response does not exist")
+	}
+	return p.template
+}
+
+//
+// Add a virtual machine template to the system from a configuration. Requires the configuration type, the configuration data, and the target cluster.
+//
+func (p *templatesService) AddFromConfiguration() *templatesServiceAddFromConfigurationRequest {
+	return &templatesServiceAddFromConfigurationRequest{templatesService: p}
+}
+
+//
+// Add a virtual machine template to the system from an existing virtual machine.
+//
+type templatesServiceAddFromVmRequest struct {
+	templatesService *templatesService
+	header           map[string]string
+	query            map[string]string
+	clonePermissions *bool
+	seal             *bool
+	template         *Template
+}
+
+func (p *templatesServiceAddFromVmRequest) Header(key, value string) *templatesServiceAddFromVmRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *templatesServiceAddFromVmRequest) Query(key, value string) *templatesServiceAddFromVmRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *templatesServiceAddFromVmRequest) ClonePermissions(clonePermissions bool) *templatesServiceAddFromVmRequest {
+	p.clonePermissions = &clonePermissions
+	return p
+}
+
+func (p *templatesServiceAddFromVmRequest) Seal(seal bool) *templatesServiceAddFromVmRequest {
+	p.seal = &seal
+	return p
+}
+
+func (p *templatesServiceAddFromVmRequest) Template(template *Template) *templatesServiceAddFromVmRequest {
+	p.template = template
+	return p
+}
+
+func (p *templatesServiceAddFromVmRequest) Send() (*templatesServiceAddFromVmResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/fromvm", p.templatesService.connection.URL(), p.templatesService.path)
+	actionBuilder := NewActionBuilder()
+	if p.clonePermissions != nil {
+		actionBuilder.ClonePermissions(*p.clonePermissions)
+	}
+	if p.seal != nil {
+		actionBuilder.Seal(*p.seal)
+	}
+	actionBuilder.Template(p.template)
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.templatesService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.templatesService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.templatesService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.templatesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templatesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	action, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	result := action.MustTemplate()
+	return &templatesServiceAddFromVmResponse{template: result}, nil
+}
+
+func (p *templatesServiceAddFromVmRequest) MustSend() *templatesServiceAddFromVmResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Add a virtual machine template to the system from an existing virtual machine.
+//
+type templatesServiceAddFromVmResponse struct {
+	template *Template
+}
+
+func (p *templatesServiceAddFromVmResponse) Template() (*Template, bool) {
+	if p.template != nil {
+		return p.template, true
+	}
+	return nil, false
+}
+
+func (p *templatesServiceAddFromVmResponse) MustTemplate() *Template {
+	if p.template == nil {
+		panic("template in response does not exist")
+	}
+	return p.template
+}
+
+//
+// Add a virtual machine template to the system from an existing virtual machine.
+//
+func (p *templatesService) AddFromVm() *templatesServiceAddFromVmRequest {
+	return &templatesServiceAddFromVmRequest{templatesService: p}
+}
+
+//
 // Returns the list of virtual machine templates.
 // For example:
 // [source]
@@ -97096,6 +105237,17 @@ func (p *templatesServiceListRequest) Send() (*templatesServiceListResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templatesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templatesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -97277,6 +105429,17 @@ func (p *storageDomainVmDiskAttachmentServiceGetRequest) Send() (*storageDomainV
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainVmDiskAttachmentService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainVmDiskAttachmentService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -97448,6 +105611,17 @@ func (p *dataCenterNetworksServiceAddRequest) Send() (*dataCenterNetworksService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.dataCenterNetworksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.dataCenterNetworksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -97611,6 +105785,17 @@ func (p *dataCenterNetworksServiceListRequest) Send() (*dataCenterNetworksServic
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.dataCenterNetworksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.dataCenterNetworksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -97804,6 +105989,17 @@ func (p *vmNumaNodesServiceAddRequest) Send() (*vmNumaNodesServiceAddResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNumaNodesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNumaNodesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -97987,6 +106183,17 @@ func (p *vmNumaNodesServiceListRequest) Send() (*vmNumaNodesServiceListResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmNumaNodesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmNumaNodesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -98176,6 +106383,17 @@ func (p *vmWatchdogsServiceAddRequest) Send() (*vmWatchdogsServiceAddResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmWatchdogsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmWatchdogsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -98351,6 +106569,17 @@ func (p *vmWatchdogsServiceListRequest) Send() (*vmWatchdogsServiceListResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmWatchdogsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmWatchdogsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -98522,6 +106751,17 @@ func (p *instanceTypeWatchdogsServiceAddRequest) Send() (*instanceTypeWatchdogsS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeWatchdogsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeWatchdogsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -98671,6 +106911,17 @@ func (p *instanceTypeWatchdogsServiceListRequest) Send() (*instanceTypeWatchdogs
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeWatchdogsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeWatchdogsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -98875,6 +107126,17 @@ func (p *stepsServiceAddRequest) Send() (*stepsServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.stepsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.stepsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -99104,6 +107366,17 @@ func (p *stepsServiceListRequest) Send() (*stepsServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.stepsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.stepsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -99357,6 +107630,17 @@ func (p *glusterVolumeServiceGetRequest) Send() (*glusterVolumeServiceGetRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -99562,6 +107846,17 @@ func (p *glusterVolumeServiceGetProfileStatisticsRequest) Send() (*glusterVolume
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -99730,6 +108025,17 @@ func (p *glusterVolumeServiceRebalanceRequest) Send() (*glusterVolumeServiceReba
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -99858,6 +108164,17 @@ func (p *glusterVolumeServiceRemoveRequest) Send() (*glusterVolumeServiceRemoveR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -99990,6 +108307,17 @@ func (p *glusterVolumeServiceResetAllOptionsRequest) Send() (*glusterVolumeServi
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -100144,6 +108472,17 @@ func (p *glusterVolumeServiceResetOptionRequest) Send() (*glusterVolumeServiceRe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -100303,6 +108642,17 @@ func (p *glusterVolumeServiceSetOptionRequest) Send() (*glusterVolumeServiceSetO
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -100457,6 +108807,17 @@ func (p *glusterVolumeServiceStartRequest) Send() (*glusterVolumeServiceStartRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -100587,6 +108948,17 @@ func (p *glusterVolumeServiceStartProfileRequest) Send() (*glusterVolumeServiceS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -100725,6 +109097,17 @@ func (p *glusterVolumeServiceStopRequest) Send() (*glusterVolumeServiceStopRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -100855,6 +109238,17 @@ func (p *glusterVolumeServiceStopProfileRequest) Send() (*glusterVolumeServiceSt
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -100984,6 +109378,17 @@ func (p *glusterVolumeServiceStopRebalanceRequest) Send() (*glusterVolumeService
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -101196,6 +109601,17 @@ func (p *glusterBricksServiceActivateRequest) Send() (*glusterBricksServiceActiv
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterBricksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterBricksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -101388,6 +109804,17 @@ func (p *glusterBricksServiceAddRequest) Send() (*glusterBricksServiceAddRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterBricksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterBricksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -101586,6 +110013,17 @@ func (p *glusterBricksServiceListRequest) Send() (*glusterBricksServiceListRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterBricksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterBricksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -101807,6 +110245,17 @@ func (p *glusterBricksServiceMigrateRequest) Send() (*glusterBricksServiceMigrat
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterBricksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterBricksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -101997,6 +110446,17 @@ func (p *glusterBricksServiceRemoveRequest) Send() (*glusterBricksServiceRemoveR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterBricksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterBricksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -102179,6 +110639,17 @@ func (p *glusterBricksServiceStopMigrateRequest) Send() (*glusterBricksServiceSt
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterBricksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterBricksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -102367,6 +110838,17 @@ func (p *glusterHooksServiceListRequest) Send() (*glusterHooksServiceListRespons
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterHooksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterHooksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -102543,6 +111025,17 @@ func (p *glusterHookServiceDisableRequest) Send() (*glusterHookServiceDisableRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterHookService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterHookService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -102659,6 +111152,17 @@ func (p *glusterHookServiceEnableRequest) Send() (*glusterHookServiceEnableRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterHookService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterHookService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -102765,6 +111269,17 @@ func (p *glusterHookServiceGetRequest) Send() (*glusterHookServiceGetResponse, e
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterHookService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterHookService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -102891,6 +111406,17 @@ func (p *glusterHookServiceRemoveRequest) Send() (*glusterHookServiceRemoveRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterHookService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterHookService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -103029,6 +111555,17 @@ func (p *glusterHookServiceResolveRequest) Send() (*glusterHookServiceResolveRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterHookService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterHookService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -103207,6 +111744,17 @@ func (p *glusterVolumesServiceAddRequest) Send() (*glusterVolumesServiceAddRespo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -103432,6 +111980,17 @@ func (p *glusterVolumesServiceListRequest) Send() (*glusterVolumesServiceListRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterVolumesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterVolumesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -103655,6 +112214,17 @@ func (p *glusterBrickServiceGetRequest) Send() (*glusterBrickServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterBrickService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterBrickService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -103875,6 +112445,17 @@ func (p *glusterBrickServiceRemoveRequest) Send() (*glusterBrickServiceRemoveRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterBrickService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterBrickService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -104019,6 +112600,17 @@ func (p *glusterBrickServiceReplaceRequest) Send() (*glusterBrickServiceReplaceR
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.glusterBrickService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.glusterBrickService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -104168,6 +112760,17 @@ func (p *macPoolServiceGetRequest) Send() (*macPoolServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.macPoolService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.macPoolService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -104299,6 +112902,17 @@ func (p *macPoolServiceRemoveRequest) Send() (*macPoolServiceRemoveResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.macPoolService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.macPoolService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -104455,6 +113069,17 @@ func (p *macPoolServiceUpdateRequest) Send() (*macPoolServiceUpdateResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.macPoolService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.macPoolService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -104687,6 +113312,17 @@ func (p *iconsServiceListRequest) Send() (*iconsServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.iconsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.iconsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -104910,6 +113546,17 @@ func (p *externalProviderCertificatesServiceListRequest) Send() (*externalProvid
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.externalProviderCertificatesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.externalProviderCertificatesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -105128,6 +113775,17 @@ func (p *rolesServiceAddRequest) Send() (*rolesServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.rolesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.rolesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -105323,6 +113981,17 @@ func (p *rolesServiceListRequest) Send() (*rolesServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.rolesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.rolesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -105526,6 +114195,17 @@ func (p *storageDomainTemplateServiceGetRequest) Send() (*storageDomainTemplateS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainTemplateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainTemplateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -105726,6 +114406,17 @@ func (p *storageDomainTemplateServiceImportRequest) Send() (*storageDomainTempla
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainTemplateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainTemplateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -105943,6 +114634,17 @@ func (p *storageDomainTemplateServiceRegisterRequest) Send() (*storageDomainTemp
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainTemplateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainTemplateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -106049,6 +114751,17 @@ func (p *storageDomainTemplateServiceRemoveRequest) Send() (*storageDomainTempla
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.storageDomainTemplateService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.storageDomainTemplateService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -106358,6 +115071,17 @@ func (p *disksServiceAddRequest) Send() (*disksServiceAddResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.disksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.disksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -106787,6 +115511,17 @@ func (p *disksServiceListRequest) Send() (*disksServiceListResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.disksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.disksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -106979,6 +115714,17 @@ func (p *disksServiceAddLunRequest) Send() (*disksServiceAddLunResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.disksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.disksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -107106,6 +115852,17 @@ func (p *disksServiceAddOnStorageDomainRequest) Send() (*disksServiceAddOnStorag
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.disksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.disksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	action, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -107268,6 +116025,17 @@ func (p *assignedDiskProfilesServiceAddRequest) Send() (*assignedDiskProfilesSer
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedDiskProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedDiskProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -107407,6 +116175,17 @@ func (p *assignedDiskProfilesServiceListRequest) Send() (*assignedDiskProfilesSe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.assignedDiskProfilesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.assignedDiskProfilesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -107578,6 +116357,17 @@ func (p *instanceTypeServiceGetRequest) Send() (*instanceTypeServiceGetResponse,
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -107720,6 +116510,17 @@ func (p *instanceTypeServiceRemoveRequest) Send() (*instanceTypeServiceRemoveRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -107876,6 +116677,17 @@ func (p *instanceTypeServiceUpdateRequest) Send() (*instanceTypeServiceUpdateRes
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.instanceTypeService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.instanceTypeService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -108126,6 +116938,17 @@ func (p *balanceServiceGetRequest) Send() (*balanceServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.balanceService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.balanceService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -108251,6 +117074,17 @@ func (p *balanceServiceRemoveRequest) Send() (*balanceServiceRemoveResponse, err
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.balanceService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.balanceService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -108387,6 +117221,17 @@ func (p *templateGraphicsConsolesServiceAddRequest) Send() (*templateGraphicsCon
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateGraphicsConsolesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateGraphicsConsolesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -108526,6 +117371,17 @@ func (p *templateGraphicsConsolesServiceListRequest) Send() (*templateGraphicsCo
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.templateGraphicsConsolesService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.templateGraphicsConsolesService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -108702,6 +117558,17 @@ func (p *vmCdromsServiceAddRequest) Send() (*vmCdromsServiceAddResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmCdromsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmCdromsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
 		return nil, CheckFault(resp)
 	}
@@ -108841,6 +117708,17 @@ func (p *vmCdromsServiceListRequest) Send() (*vmCdromsServiceListResponse, error
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.vmCdromsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.vmCdromsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -109022,6 +117900,17 @@ func (p *clusterEnabledFeatureServiceGetRequest) Send() (*clusterEnabledFeatureS
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterEnabledFeatureService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterEnabledFeatureService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -109169,6 +118058,17 @@ func (p *clusterEnabledFeatureServiceRemoveRequest) Send() (*clusterEnabledFeatu
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.clusterEnabledFeatureService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.clusterEnabledFeatureService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}
@@ -109355,6 +118255,17 @@ func (p *stepServiceEndRequest) Send() (*stepServiceEndResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.stepService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.stepService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	_, errCheckAction := CheckAction(resp)
 	if errCheckAction != nil {
 		return nil, errCheckAction
@@ -109509,6 +118420,17 @@ func (p *stepServiceGetRequest) Send() (*stepServiceGetResponse, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if p.stepService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.stepService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
 	if !Contains(resp.StatusCode, []int{200}) {
 		return nil, CheckFault(resp)
 	}

--- a/vendor/gopkg.in/imjoey/go-ovirt.v4/types.go
+++ b/vendor/gopkg.in/imjoey/go-ovirt.v4/types.go
@@ -4549,6 +4549,7 @@ type VmBase struct {
 	memoryPolicy                *MemoryPolicy
 	migration                   *MigrationOptions
 	migrationDowntime           *int64
+	multiQueuesEnabled          *bool
 	name                        *string
 	origin                      *string
 	os                          *OperatingSystem
@@ -5046,6 +5047,25 @@ func (p *VmBase) MustMigrationDowntime() int64 {
 		panic("the migrationDowntime must not be nil, please use MigrationDowntime() function instead")
 	}
 	return *p.migrationDowntime
+}
+
+func (p *VmBase) SetMultiQueuesEnabled(attr bool) {
+	p.multiQueuesEnabled = &attr
+}
+
+func (p *VmBase) MultiQueuesEnabled() (bool, bool) {
+	if p.multiQueuesEnabled != nil {
+		return *p.multiQueuesEnabled, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *VmBase) MustMultiQueuesEnabled() bool {
+	if p.multiQueuesEnabled == nil {
+		panic("the multiQueuesEnabled must not be nil, please use MultiQueuesEnabled() function instead")
+	}
+	return *p.multiQueuesEnabled
 }
 
 func (p *VmBase) SetName(attr string) {
@@ -7364,6 +7384,8 @@ type OpenStackNetworkProvider struct {
 	networks               *OpenStackNetworkSlice
 	password               *string
 	pluginType             *NetworkPluginType
+	projectDomainName      *string
+	projectName            *string
 	properties             *PropertySlice
 	readOnly               *bool
 	requiresAuthentication *bool
@@ -7372,6 +7394,7 @@ type OpenStackNetworkProvider struct {
 	type_                  *OpenStackNetworkProviderType
 	unmanaged              *bool
 	url                    *string
+	userDomainName         *string
 	username               *string
 }
 
@@ -7600,6 +7623,44 @@ func (p *OpenStackNetworkProvider) MustPluginType() NetworkPluginType {
 	return *p.pluginType
 }
 
+func (p *OpenStackNetworkProvider) SetProjectDomainName(attr string) {
+	p.projectDomainName = &attr
+}
+
+func (p *OpenStackNetworkProvider) ProjectDomainName() (string, bool) {
+	if p.projectDomainName != nil {
+		return *p.projectDomainName, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *OpenStackNetworkProvider) MustProjectDomainName() string {
+	if p.projectDomainName == nil {
+		panic("the projectDomainName must not be nil, please use ProjectDomainName() function instead")
+	}
+	return *p.projectDomainName
+}
+
+func (p *OpenStackNetworkProvider) SetProjectName(attr string) {
+	p.projectName = &attr
+}
+
+func (p *OpenStackNetworkProvider) ProjectName() (string, bool) {
+	if p.projectName != nil {
+		return *p.projectName, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *OpenStackNetworkProvider) MustProjectName() string {
+	if p.projectName == nil {
+		panic("the projectName must not be nil, please use ProjectName() function instead")
+	}
+	return *p.projectName
+}
+
 func (p *OpenStackNetworkProvider) SetProperties(attr *PropertySlice) {
 	p.properties = attr
 }
@@ -7748,6 +7809,25 @@ func (p *OpenStackNetworkProvider) MustUrl() string {
 		panic("the url must not be nil, please use Url() function instead")
 	}
 	return *p.url
+}
+
+func (p *OpenStackNetworkProvider) SetUserDomainName(attr string) {
+	p.userDomainName = &attr
+}
+
+func (p *OpenStackNetworkProvider) UserDomainName() (string, bool) {
+	if p.userDomainName != nil {
+		return *p.userDomainName, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *OpenStackNetworkProvider) MustUserDomainName() string {
+	if p.userDomainName == nil {
+		panic("the userDomainName must not be nil, please use UserDomainName() function instead")
+	}
+	return *p.userDomainName
 }
 
 func (p *OpenStackNetworkProvider) SetUsername(attr string) {
@@ -11210,21 +11290,22 @@ func (p *Package) MustName() string {
 
 type ImageTransfer struct {
 	Struct
-	active       *bool
-	comment      *string
-	description  *string
-	direction    *ImageTransferDirection
-	disk         *Disk
-	host         *Host
-	id           *string
-	image        *Image
-	name         *string
-	phase        *ImageTransferPhase
-	proxyUrl     *string
-	signedTicket *string
-	snapshot     *DiskSnapshot
-	transferUrl  *string
-	transferred  *int64
+	active            *bool
+	comment           *string
+	description       *string
+	direction         *ImageTransferDirection
+	disk              *Disk
+	host              *Host
+	id                *string
+	image             *Image
+	inactivityTimeout *int64
+	name              *string
+	phase             *ImageTransferPhase
+	proxyUrl          *string
+	signedTicket      *string
+	snapshot          *DiskSnapshot
+	transferUrl       *string
+	transferred       *int64
 }
 
 func (p *ImageTransfer) SetActive(attr bool) {
@@ -11374,6 +11455,25 @@ func (p *ImageTransfer) MustImage() *Image {
 		panic("the image must not be nil, please use Image() function instead")
 	}
 	return p.image
+}
+
+func (p *ImageTransfer) SetInactivityTimeout(attr int64) {
+	p.inactivityTimeout = &attr
+}
+
+func (p *ImageTransfer) InactivityTimeout() (int64, bool) {
+	if p.inactivityTimeout != nil {
+		return *p.inactivityTimeout, true
+	}
+	var zero int64
+	return zero, false
+}
+
+func (p *ImageTransfer) MustInactivityTimeout() int64 {
+	if p.inactivityTimeout == nil {
+		panic("the inactivityTimeout must not be nil, please use InactivityTimeout() function instead")
+	}
+	return *p.inactivityTimeout
 }
 
 func (p *ImageTransfer) SetName(attr string) {
@@ -15409,6 +15509,7 @@ type InstanceType struct {
 	memoryPolicy                *MemoryPolicy
 	migration                   *MigrationOptions
 	migrationDowntime           *int64
+	multiQueuesEnabled          *bool
 	name                        *string
 	nics                        *NicSlice
 	origin                      *string
@@ -15967,6 +16068,25 @@ func (p *InstanceType) MustMigrationDowntime() int64 {
 		panic("the migrationDowntime must not be nil, please use MigrationDowntime() function instead")
 	}
 	return *p.migrationDowntime
+}
+
+func (p *InstanceType) SetMultiQueuesEnabled(attr bool) {
+	p.multiQueuesEnabled = &attr
+}
+
+func (p *InstanceType) MultiQueuesEnabled() (bool, bool) {
+	if p.multiQueuesEnabled != nil {
+		return *p.multiQueuesEnabled, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *InstanceType) MustMultiQueuesEnabled() bool {
+	if p.multiQueuesEnabled == nil {
+		panic("the multiQueuesEnabled must not be nil, please use MultiQueuesEnabled() function instead")
+	}
+	return *p.multiQueuesEnabled
 }
 
 func (p *InstanceType) SetName(attr string) {
@@ -16983,6 +17103,7 @@ type Snapshot struct {
 	memoryPolicy                *MemoryPolicy
 	migration                   *MigrationOptions
 	migrationDowntime           *int64
+	multiQueuesEnabled          *bool
 	name                        *string
 	nextRunConfigurationExists  *bool
 	nics                        *NicSlice
@@ -17797,6 +17918,25 @@ func (p *Snapshot) MustMigrationDowntime() int64 {
 		panic("the migrationDowntime must not be nil, please use MigrationDowntime() function instead")
 	}
 	return *p.migrationDowntime
+}
+
+func (p *Snapshot) SetMultiQueuesEnabled(attr bool) {
+	p.multiQueuesEnabled = &attr
+}
+
+func (p *Snapshot) MultiQueuesEnabled() (bool, bool) {
+	if p.multiQueuesEnabled != nil {
+		return *p.multiQueuesEnabled, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Snapshot) MustMultiQueuesEnabled() bool {
+	if p.multiQueuesEnabled == nil {
+		panic("the multiQueuesEnabled must not be nil, please use MultiQueuesEnabled() function instead")
+	}
+	return *p.multiQueuesEnabled
 }
 
 func (p *Snapshot) SetName(attr string) {
@@ -23020,6 +23160,7 @@ type Template struct {
 	memoryPolicy                *MemoryPolicy
 	migration                   *MigrationOptions
 	migrationDowntime           *int64
+	multiQueuesEnabled          *bool
 	name                        *string
 	nics                        *NicSlice
 	origin                      *string
@@ -23578,6 +23719,25 @@ func (p *Template) MustMigrationDowntime() int64 {
 		panic("the migrationDowntime must not be nil, please use MigrationDowntime() function instead")
 	}
 	return *p.migrationDowntime
+}
+
+func (p *Template) SetMultiQueuesEnabled(attr bool) {
+	p.multiQueuesEnabled = &attr
+}
+
+func (p *Template) MultiQueuesEnabled() (bool, bool) {
+	if p.multiQueuesEnabled != nil {
+		return *p.multiQueuesEnabled, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Template) MustMultiQueuesEnabled() bool {
+	if p.multiQueuesEnabled == nil {
+		panic("the multiQueuesEnabled must not be nil, please use MultiQueuesEnabled() function instead")
+	}
+	return *p.multiQueuesEnabled
 }
 
 func (p *Template) SetName(attr string) {
@@ -30614,24 +30774,25 @@ func (p *ExternalHostGroup) MustSubnetName() string {
 
 type StorageConnection struct {
 	Struct
-	address      *string
-	comment      *string
-	description  *string
-	host         *Host
-	id           *string
-	mountOptions *string
-	name         *string
-	nfsRetrans   *int64
-	nfsTimeo     *int64
-	nfsVersion   *NfsVersion
-	password     *string
-	path         *string
-	port         *int64
-	portal       *string
-	target       *string
-	type_        *StorageType
-	username     *string
-	vfsType      *string
+	address       *string
+	comment       *string
+	description   *string
+	glusterVolume *GlusterVolume
+	host          *Host
+	id            *string
+	mountOptions  *string
+	name          *string
+	nfsRetrans    *int64
+	nfsTimeo      *int64
+	nfsVersion    *NfsVersion
+	password      *string
+	path          *string
+	port          *int64
+	portal        *string
+	target        *string
+	type_         *StorageType
+	username      *string
+	vfsType       *string
 }
 
 func (p *StorageConnection) SetAddress(attr string) {
@@ -30689,6 +30850,24 @@ func (p *StorageConnection) MustDescription() string {
 		panic("the description must not be nil, please use Description() function instead")
 	}
 	return *p.description
+}
+
+func (p *StorageConnection) SetGlusterVolume(attr *GlusterVolume) {
+	p.glusterVolume = attr
+}
+
+func (p *StorageConnection) GlusterVolume() (*GlusterVolume, bool) {
+	if p.glusterVolume != nil {
+		return p.glusterVolume, true
+	}
+	return nil, false
+}
+
+func (p *StorageConnection) MustGlusterVolume() *GlusterVolume {
+	if p.glusterVolume == nil {
+		panic("the glusterVolume must not be nil, please use GlusterVolume() function instead")
+	}
+	return p.glusterVolume
 }
 
 func (p *StorageConnection) SetHost(attr *Host) {
@@ -32814,6 +32993,7 @@ type Host struct {
 	memory                                *int64
 	name                                  *string
 	networkAttachments                    *NetworkAttachmentSlice
+	networkOperationInProgress            *bool
 	nics                                  *HostNicSlice
 	numaNodes                             *NumaNodeSlice
 	numaSupported                         *bool
@@ -33353,6 +33533,25 @@ func (p *Host) MustNetworkAttachments() *NetworkAttachmentSlice {
 		panic("the networkAttachments must not be nil, please use NetworkAttachments() function instead")
 	}
 	return p.networkAttachments
+}
+
+func (p *Host) SetNetworkOperationInProgress(attr bool) {
+	p.networkOperationInProgress = &attr
+}
+
+func (p *Host) NetworkOperationInProgress() (bool, bool) {
+	if p.networkOperationInProgress != nil {
+		return *p.networkOperationInProgress, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Host) MustNetworkOperationInProgress() bool {
+	if p.networkOperationInProgress == nil {
+		panic("the networkOperationInProgress must not be nil, please use NetworkOperationInProgress() function instead")
+	}
+	return *p.networkOperationInProgress
 }
 
 func (p *Host) SetNics(attr *HostNicSlice) {
@@ -33960,12 +34159,32 @@ func (p *Certificate) MustSubject() string {
 
 type OperatingSystemInfo struct {
 	Struct
-	comment     *string
-	description *string
-	id          *string
-	largeIcon   *Icon
-	name        *string
-	smallIcon   *Icon
+	architecture *Architecture
+	comment      *string
+	description  *string
+	id           *string
+	largeIcon    *Icon
+	name         *string
+	smallIcon    *Icon
+}
+
+func (p *OperatingSystemInfo) SetArchitecture(attr Architecture) {
+	p.architecture = &attr
+}
+
+func (p *OperatingSystemInfo) Architecture() (Architecture, bool) {
+	if p.architecture != nil {
+		return *p.architecture, true
+	}
+	var zero Architecture
+	return zero, false
+}
+
+func (p *OperatingSystemInfo) MustArchitecture() Architecture {
+	if p.architecture == nil {
+		panic("the architecture must not be nil, please use Architecture() function instead")
+	}
+	return *p.architecture
 }
 
 func (p *OperatingSystemInfo) SetComment(attr string) {
@@ -34123,6 +34342,7 @@ type Vm struct {
 	memoryPolicy                *MemoryPolicy
 	migration                   *MigrationOptions
 	migrationDowntime           *int64
+	multiQueuesEnabled          *bool
 	name                        *string
 	nextRunConfigurationExists  *bool
 	nics                        *NicSlice
@@ -34914,6 +35134,25 @@ func (p *Vm) MustMigrationDowntime() int64 {
 		panic("the migrationDowntime must not be nil, please use MigrationDowntime() function instead")
 	}
 	return *p.migrationDowntime
+}
+
+func (p *Vm) SetMultiQueuesEnabled(attr bool) {
+	p.multiQueuesEnabled = &attr
+}
+
+func (p *Vm) MultiQueuesEnabled() (bool, bool) {
+	if p.multiQueuesEnabled != nil {
+		return *p.multiQueuesEnabled, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Vm) MustMultiQueuesEnabled() bool {
+	if p.multiQueuesEnabled == nil {
+		panic("the multiQueuesEnabled must not be nil, please use MultiQueuesEnabled() function instead")
+	}
+	return *p.multiQueuesEnabled
 }
 
 func (p *Vm) SetName(attr string) {
@@ -37715,6 +37954,7 @@ type Action struct {
 	resolutionType                 *string
 	restoreMemory                  *bool
 	rootPassword                   *string
+	seal                           *bool
 	snapshot                       *Snapshot
 	ssh                            *Ssh
 	status                         *string
@@ -38934,6 +39174,25 @@ func (p *Action) MustRootPassword() string {
 		panic("the rootPassword must not be nil, please use RootPassword() function instead")
 	}
 	return *p.rootPassword
+}
+
+func (p *Action) SetSeal(attr bool) {
+	p.seal = &attr
+}
+
+func (p *Action) Seal() (bool, bool) {
+	if p.seal != nil {
+		return *p.seal, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Action) MustSeal() bool {
+	if p.seal == nil {
+		panic("the seal must not be nil, please use Seal() function instead")
+	}
+	return *p.seal
 }
 
 func (p *Action) SetSnapshot(attr *Snapshot) {
@@ -49463,6 +49722,15 @@ func (builder *VmBaseBuilder) MigrationDowntime(attr int64) *VmBaseBuilder {
 	return builder
 }
 
+func (builder *VmBaseBuilder) MultiQueuesEnabled(attr bool) *VmBaseBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.vmBase.SetMultiQueuesEnabled(attr)
+	return builder
+}
+
 func (builder *VmBaseBuilder) Name(attr string) *VmBaseBuilder {
 	if builder.err != nil {
 		return builder
@@ -52157,6 +52425,24 @@ func (builder *OpenStackNetworkProviderBuilder) PluginType(attr NetworkPluginTyp
 	return builder
 }
 
+func (builder *OpenStackNetworkProviderBuilder) ProjectDomainName(attr string) *OpenStackNetworkProviderBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.openStackNetworkProvider.SetProjectDomainName(attr)
+	return builder
+}
+
+func (builder *OpenStackNetworkProviderBuilder) ProjectName(attr string) *OpenStackNetworkProviderBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.openStackNetworkProvider.SetProjectName(attr)
+	return builder
+}
+
 func (builder *OpenStackNetworkProviderBuilder) Properties(attr *PropertySlice) *OpenStackNetworkProviderBuilder {
 	if builder.err != nil {
 		return builder
@@ -52290,6 +52576,15 @@ func (builder *OpenStackNetworkProviderBuilder) Url(attr string) *OpenStackNetwo
 	}
 
 	builder.openStackNetworkProvider.SetUrl(attr)
+	return builder
+}
+
+func (builder *OpenStackNetworkProviderBuilder) UserDomainName(attr string) *OpenStackNetworkProviderBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.openStackNetworkProvider.SetUserDomainName(attr)
 	return builder
 }
 
@@ -55747,6 +56042,15 @@ func (builder *ImageTransferBuilder) ImageBuilder(attrBuilder *ImageBuilder) *Im
 		return builder
 	}
 	return builder.Image(attr)
+}
+
+func (builder *ImageTransferBuilder) InactivityTimeout(attr int64) *ImageTransferBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.imageTransfer.SetInactivityTimeout(attr)
+	return builder
 }
 
 func (builder *ImageTransferBuilder) Name(attr string) *ImageTransferBuilder {
@@ -60603,6 +60907,15 @@ func (builder *InstanceTypeBuilder) MigrationDowntime(attr int64) *InstanceTypeB
 	return builder
 }
 
+func (builder *InstanceTypeBuilder) MultiQueuesEnabled(attr bool) *InstanceTypeBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.instanceType.SetMultiQueuesEnabled(attr)
+	return builder
+}
+
 func (builder *InstanceTypeBuilder) Name(attr string) *InstanceTypeBuilder {
 	if builder.err != nil {
 		return builder
@@ -62761,6 +63074,15 @@ func (builder *SnapshotBuilder) MigrationDowntime(attr int64) *SnapshotBuilder {
 	}
 
 	builder.snapshot.SetMigrationDowntime(attr)
+	return builder
+}
+
+func (builder *SnapshotBuilder) MultiQueuesEnabled(attr bool) *SnapshotBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.snapshot.SetMultiQueuesEnabled(attr)
 	return builder
 }
 
@@ -68148,6 +68470,15 @@ func (builder *TemplateBuilder) MigrationDowntime(attr int64) *TemplateBuilder {
 	}
 
 	builder.template.SetMigrationDowntime(attr)
+	return builder
+}
+
+func (builder *TemplateBuilder) MultiQueuesEnabled(attr bool) *TemplateBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.template.SetMultiQueuesEnabled(attr)
 	return builder
 }
 
@@ -75460,6 +75791,32 @@ func (builder *StorageConnectionBuilder) Description(attr string) *StorageConnec
 	return builder
 }
 
+func (builder *StorageConnectionBuilder) GlusterVolume(attr *GlusterVolume) *StorageConnectionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.storageConnection.SetGlusterVolume(attr)
+	return builder
+}
+
+func (builder *StorageConnectionBuilder) GlusterVolumeBuilder(attrBuilder *GlusterVolumeBuilder) *StorageConnectionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	if attrBuilder.err != nil {
+		builder.err = attrBuilder.err
+		return builder
+	}
+	attr, err := attrBuilder.Build()
+	if err != nil {
+		builder.err = err
+		return builder
+	}
+	return builder.GlusterVolume(attr)
+}
+
 func (builder *StorageConnectionBuilder) Host(attr *Host) *StorageConnectionBuilder {
 	if builder.err != nil {
 		return builder
@@ -78394,6 +78751,15 @@ func (builder *HostBuilder) NetworkAttachmentsBuilderOfAny(anyBuilders ...Networ
 	return builder
 }
 
+func (builder *HostBuilder) NetworkOperationInProgress(attr bool) *HostBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.host.SetNetworkOperationInProgress(attr)
+	return builder
+}
+
 func (builder *HostBuilder) Nics(attr *HostNicSlice) *HostBuilder {
 	if builder.err != nil {
 		return builder
@@ -79136,6 +79502,15 @@ type OperatingSystemInfoBuilder struct {
 
 func NewOperatingSystemInfoBuilder() *OperatingSystemInfoBuilder {
 	return &OperatingSystemInfoBuilder{operatingSystemInfo: &OperatingSystemInfo{}, err: nil}
+}
+
+func (builder *OperatingSystemInfoBuilder) Architecture(attr Architecture) *OperatingSystemInfoBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.operatingSystemInfo.SetArchitecture(attr)
+	return builder
 }
 
 func (builder *OperatingSystemInfoBuilder) Comment(attr string) *OperatingSystemInfoBuilder {
@@ -80252,6 +80627,15 @@ func (builder *VmBuilder) MigrationDowntime(attr int64) *VmBuilder {
 	}
 
 	builder.vm.SetMigrationDowntime(attr)
+	return builder
+}
+
+func (builder *VmBuilder) MultiQueuesEnabled(attr bool) *VmBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.vm.SetMultiQueuesEnabled(attr)
 	return builder
 }
 
@@ -84804,6 +85188,15 @@ func (builder *ActionBuilder) RootPassword(attr string) *ActionBuilder {
 	return builder
 }
 
+func (builder *ActionBuilder) Seal(attr bool) *ActionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.action.SetSeal(attr)
+	return builder
+}
+
 func (builder *ActionBuilder) Snapshot(attr *Snapshot) *ActionBuilder {
 	if builder.err != nil {
 		return builder
@@ -85800,10 +86193,11 @@ const (
 type BootProtocol string
 
 const (
-	BOOTPROTOCOL_AUTOCONF BootProtocol = "autoconf"
-	BOOTPROTOCOL_DHCP     BootProtocol = "dhcp"
-	BOOTPROTOCOL_NONE     BootProtocol = "none"
-	BOOTPROTOCOL_STATIC   BootProtocol = "static"
+	BOOTPROTOCOL_AUTOCONF           BootProtocol = "autoconf"
+	BOOTPROTOCOL_DHCP               BootProtocol = "dhcp"
+	BOOTPROTOCOL_NONE               BootProtocol = "none"
+	BOOTPROTOCOL_POLY_DHCP_AUTOCONF BootProtocol = "poly_dhcp_autoconf"
+	BOOTPROTOCOL_STATIC             BootProtocol = "static"
 )
 
 type HostType string

--- a/vendor/gopkg.in/imjoey/go-ovirt.v4/version.go
+++ b/vendor/gopkg.in/imjoey/go-ovirt.v4/version.go
@@ -16,4 +16,4 @@
 package ovirtsdk
 
 // The version of the SDK:
-var SDK_VERSION = "4.3.0.a1"
+var SDK_VERSION = "4.0.5"

--- a/vendor/gopkg.in/imjoey/go-ovirt.v4/writers.go
+++ b/vendor/gopkg.in/imjoey/go-ovirt.v4/writers.go
@@ -1617,6 +1617,9 @@ func XMLVmBaseWriteOne(writer *XMLWriter, object *VmBase, tag string) error {
 	if r, ok := object.MigrationDowntime(); ok {
 		writer.WriteInt64("migration_downtime", r)
 	}
+	if r, ok := object.MultiQueuesEnabled(); ok {
+		writer.WriteBool("multi_queues_enabled", r)
+	}
 	if r, ok := object.Name(); ok {
 		writer.WriteCharacter("name", r)
 	}
@@ -2481,6 +2484,12 @@ func XMLOpenStackNetworkProviderWriteOne(writer *XMLWriter, object *OpenStackNet
 	if r, ok := object.PluginType(); ok {
 		XMLNetworkPluginTypeWriteOne(writer, r, "plugin_type")
 	}
+	if r, ok := object.ProjectDomainName(); ok {
+		writer.WriteCharacter("project_domain_name", r)
+	}
+	if r, ok := object.ProjectName(); ok {
+		writer.WriteCharacter("project_name", r)
+	}
 	if r, ok := object.Properties(); ok {
 		XMLPropertyWriteMany(writer, r, "properties", "property")
 	}
@@ -2504,6 +2513,9 @@ func XMLOpenStackNetworkProviderWriteOne(writer *XMLWriter, object *OpenStackNet
 	}
 	if r, ok := object.Url(); ok {
 		writer.WriteCharacter("url", r)
+	}
+	if r, ok := object.UserDomainName(); ok {
+		writer.WriteCharacter("user_domain_name", r)
 	}
 	if r, ok := object.Username(); ok {
 		writer.WriteCharacter("username", r)
@@ -3706,6 +3718,9 @@ func XMLImageTransferWriteOne(writer *XMLWriter, object *ImageTransfer, tag stri
 	}
 	if r, ok := object.Image(); ok {
 		XMLImageWriteOne(writer, r, "image")
+	}
+	if r, ok := object.InactivityTimeout(); ok {
+		writer.WriteInt64("inactivity_timeout", r)
 	}
 	if r, ok := object.Name(); ok {
 		writer.WriteCharacter("name", r)
@@ -5266,6 +5281,9 @@ func XMLInstanceTypeWriteOne(writer *XMLWriter, object *InstanceType, tag string
 	if r, ok := object.MigrationDowntime(); ok {
 		writer.WriteInt64("migration_downtime", r)
 	}
+	if r, ok := object.MultiQueuesEnabled(); ok {
+		writer.WriteBool("multi_queues_enabled", r)
+	}
 	if r, ok := object.Name(); ok {
 		writer.WriteCharacter("name", r)
 	}
@@ -5715,6 +5733,9 @@ func XMLSnapshotWriteOne(writer *XMLWriter, object *Snapshot, tag string) error 
 	}
 	if r, ok := object.MigrationDowntime(); ok {
 		writer.WriteInt64("migration_downtime", r)
+	}
+	if r, ok := object.MultiQueuesEnabled(); ok {
+		writer.WriteBool("multi_queues_enabled", r)
 	}
 	if r, ok := object.Name(); ok {
 		writer.WriteCharacter("name", r)
@@ -7480,6 +7501,9 @@ func XMLTemplateWriteOne(writer *XMLWriter, object *Template, tag string) error 
 	}
 	if r, ok := object.MigrationDowntime(); ok {
 		writer.WriteInt64("migration_downtime", r)
+	}
+	if r, ok := object.MultiQueuesEnabled(); ok {
+		writer.WriteBool("multi_queues_enabled", r)
 	}
 	if r, ok := object.Name(); ok {
 		writer.WriteCharacter("name", r)
@@ -9788,6 +9812,9 @@ func XMLStorageConnectionWriteOne(writer *XMLWriter, object *StorageConnection, 
 	if r, ok := object.Description(); ok {
 		writer.WriteCharacter("description", r)
 	}
+	if r, ok := object.GlusterVolume(); ok {
+		XMLGlusterVolumeWriteOne(writer, r, "gluster_volume")
+	}
 	if r, ok := object.Host(); ok {
 		XMLHostWriteOne(writer, r, "host")
 	}
@@ -10536,6 +10563,9 @@ func XMLHostWriteOne(writer *XMLWriter, object *Host, tag string) error {
 	if r, ok := object.NetworkAttachments(); ok {
 		XMLNetworkAttachmentWriteMany(writer, r, "network_attachments", "network_attachment")
 	}
+	if r, ok := object.NetworkOperationInProgress(); ok {
+		writer.WriteBool("network_operation_in_progress", r)
+	}
 	if r, ok := object.Nics(); ok {
 		XMLHostNicWriteMany(writer, r, "nics", "host_nic")
 	}
@@ -10697,6 +10727,9 @@ func XMLOperatingSystemInfoWriteOne(writer *XMLWriter, object *OperatingSystemIn
 		attrs["id"] = r
 	}
 	writer.WriteStart("", tag, attrs)
+	if r, ok := object.Architecture(); ok {
+		XMLArchitectureWriteOne(writer, r, "architecture")
+	}
 	if r, ok := object.Comment(); ok {
 		writer.WriteCharacter("comment", r)
 	}
@@ -10865,6 +10898,9 @@ func XMLVmWriteOne(writer *XMLWriter, object *Vm, tag string) error {
 	}
 	if r, ok := object.MigrationDowntime(); ok {
 		writer.WriteInt64("migration_downtime", r)
+	}
+	if r, ok := object.MultiQueuesEnabled(); ok {
+		writer.WriteBool("multi_queues_enabled", r)
 	}
 	if r, ok := object.Name(); ok {
 		writer.WriteCharacter("name", r)
@@ -11937,6 +11973,9 @@ func XMLActionWriteOne(writer *XMLWriter, object *Action, tag string) error {
 	}
 	if r, ok := object.RootPassword(); ok {
 		writer.WriteCharacter("root_password", r)
+	}
+	if r, ok := object.Seal(); ok {
+		writer.WriteBool("seal", r)
 	}
 	if r, ok := object.Snapshot(); ok {
 		XMLSnapshotWriteOne(writer, r, "snapshot")


### PR DESCRIPTION
See https://github.com/imjoey/ovirt-engine-sdk-go/pull/131 and https://github.com/imjoey/ovirt-engine-sdk-go/pull/130 for the details of new release go-ovirt sdk.