### PR TITLE
New Data Source: ovirt_authzs

### DIFF
--- a/ovirt/data_source_ovirt_authzs.go
+++ b/ovirt/data_source_ovirt_authzs.go
@@ -1,0 +1,98 @@
+// Copyright (C) 2018 Joey Ma <majunjiev@gmail.com>
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func dataSourceOvirtAuthzs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOvirtAuthzsRead,
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.ValidateRegexp,
+			},
+
+			"authzs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOvirtAuthzsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	req := conn.SystemService().DomainsService().List()
+
+	resp, err := req.Send()
+	if err != nil {
+		return err
+	}
+	authzs, ok := resp.Domains()
+	if !ok || len(authzs.Slice()) == 0 {
+		return fmt.Errorf("no authzs exists")
+	}
+
+	var filteredAuthzs []*ovirtsdk4.Domain
+
+	nameRegex, nameRegexOK := d.GetOk("name_regex")
+	if nameRegexOK {
+		r := regexp.MustCompile(nameRegex.(string))
+		for _, c := range authzs.Slice() {
+			if r.MatchString(c.MustName()) {
+				filteredAuthzs = append(filteredAuthzs, c)
+			}
+		}
+	} else {
+		filteredAuthzs = authzs.Slice()[:]
+	}
+
+	if len(filteredAuthzs) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+
+	return authzsDescriptionAttributes(d, filteredAuthzs, meta)
+}
+
+func authzsDescriptionAttributes(d *schema.ResourceData, authzs []*ovirtsdk4.Domain, meta interface{}) error {
+	var s []map[string]interface{}
+	for _, v := range authzs {
+		mapping := map[string]interface{}{
+			"id":   v.MustId(),
+			"name": v.MustName(),
+		}
+		s = append(s, mapping)
+	}
+
+	d.SetId(resource.UniqueId())
+	return d.Set("authzs", s)
+}

--- a/ovirt/data_source_ovirt_authzs_test.go
+++ b/ovirt/data_source_ovirt_authzs_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2018 Joey Ma <majunjiev@gmail.com>
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOvirtAuthzsDataSource_nameRegexFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtAuthzsDataSourceNameRegexConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_authzs.name_regex_filtered_authz"),
+					resource.TestCheckResourceAttr("data.ovirt_authzs.name_regex_filtered_authz", "authzs.#", "1"),
+					resource.TestMatchResourceAttr("data.ovirt_authzs.name_regex_filtered_authz", "authzs.0.name", regexp.MustCompile("^internal-*")),
+				),
+			},
+		},
+	})
+}
+
+var testAccCheckOvirtAuthzsDataSourceNameRegexConfig = `
+data "ovirt_authzs" "name_regex_filtered_authz" {
+	name_regex = "^internal-*"
+}
+`

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -63,6 +63,7 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_clusters":       dataSourceOvirtClusters(),
 			"ovirt_storagedomains": dataSourceOvirtStorageDomains(),
 			"ovirt_vnic_profiles":  dataSourceOvirtVNicProfiles(),
+			"ovirt_authzs":         dataSourceOvirtAuthzs(),
 		},
 	}
 }


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #96 .

Changes proposed in this pull request:

* Add new data source `ovirt_authzs`
* Add acceptance testing for it

Note that using `ovirt_authzs` as the name of new data source which represents the `Domain` instead of `ovirt_domains` is to coincide with the one in Ansible oVirt Module [1](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/ovirt/ovirt_user.py#L45).

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtAuthzsDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtAuthzsDataSource_ -timeout 180m
=== RUN   TestAccOvirtAuthzsDataSource_nameRegexFilter
--- PASS: TestAccOvirtAuthzsDataSource_nameRegexFilter (1.02s)
PASS
ok  	github.com/imjoey/terraform-provider-ovirt/ovirt	1.046s
```
