### PR TITLE
Add support specifying subfields explicitly for search fields

### DIFF
--- a/ovirt/data_source_ovirt_authzs_test.go
+++ b/ovirt/data_source_ovirt_authzs_test.go
@@ -33,5 +33,8 @@ func TestAccOvirtAuthzsDataSource_nameRegexFilter(t *testing.T) {
 var testAccCheckOvirtAuthzsDataSourceNameRegexConfig = `
 data "ovirt_authzs" "name_regex_filtered_authz" {
 	name_regex = "^internal-*"
+	search {
+		max = 1
+	}
 }
 `

--- a/ovirt/data_source_ovirt_common_schema.go
+++ b/ovirt/data_source_ovirt_common_schema.go
@@ -32,3 +32,36 @@ func dataSourceSearchSchema() *schema.Schema {
 		},
 	}
 }
+
+// Helper method to support the customization of search field
+func dataSourceSearchSchemaWith(vs ...string) *schema.Schema {
+	schemaMap := make(map[string]*schema.Schema)
+	for _, v := range vs {
+		switch v {
+		case "criteria":
+			schemaMap[v] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			}
+		case "max":
+			schemaMap[v] = &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			}
+		case "case_sensitive":
+			schemaMap[v] = &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			}
+		}
+	}
+	return &schema.Schema{
+		Type:     schema.TypeMap,
+		Optional: true,
+		ForceNew: true,
+		Elem: &schema.Resource{
+			Schema: schemaMap,
+		},
+	}
+}


### PR DESCRIPTION
Changes proposed in this pull request:

* Add new `dataSourceSearchSchemaWith()` function
* Add missing `search.max` field support for data source `ovirt_authzs`

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtAuthzsDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtAuthzsDataSource_ -timeout 180m
=== RUN   TestAccOvirtAuthzsDataSource_nameRegexFilter
--- PASS: TestAccOvirtAuthzsDataSource_nameRegexFilter (2.03s)
PASS
ok  	github.com/imjoey/terraform-provider-ovirt/ovirt	2.058s
```
