### PR TITLE
New Resource: ovirt_mac_pool

### DIFF
--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -57,6 +57,7 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_storage_domain":  resourceOvirtStorageDomain(),
 			"ovirt_user":            resourceOvirtUser(),
 			"ovirt_cluster":         resourceOvirtCluster(),
+			"ovirt_mac_pool":        resourceOvirtMacPool(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ovirt_disks":          dataSourceOvirtDisks(),

--- a/ovirt/resource_ovirt_mac_pool.go
+++ b/ovirt/resource_ovirt_mac_pool.go
@@ -1,0 +1,185 @@
+// Copyright (C) 2018 Joey Ma <majunjiev@gmail.com>
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func resourceOvirtMacPool() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOvirtMacPoolCreate,
+		Read:   resourceOvirtMacPoolRead,
+		Update: resourceOvirtMacPoolUpdate,
+		Delete: resourceOvirtMacPoolDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Default:  "",
+			},
+			"allow_duplicates": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Default:  false,
+			},
+			"ranges": {
+				Type:     schema.TypeSet,
+				MinItems: 1,
+				Required: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: macRange(),
+				},
+				ForceNew:    false,
+				Description: "MAC ranges that the from and to should be split by comma",
+			},
+		},
+	}
+}
+
+func resourceOvirtMacPoolCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	mpBuilder := ovirtsdk4.NewMacPoolBuilder().
+		Name(d.Get("name").(string)).
+		Description(d.Get("description").(string)).
+		AllowDuplicates(d.Get("allow_duplicates").(bool)).
+		RangesOfAny(expandMacPoolRanges(d.Get("ranges").(*schema.Set))...)
+
+	resp, err := conn.SystemService().
+		MacPoolsService().
+		Add().
+		Pool(mpBuilder.MustBuild()).
+		Send()
+	if err != nil {
+		log.Printf("[DEBUG] Error adding new MacPool (%s): %s", d.Get("name").(string), err)
+		return err
+	}
+	d.SetId(resp.MustPool().MustId())
+
+	return resourceOvirtMacPoolRead(d, meta)
+}
+
+func resourceOvirtMacPoolRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	resp, err := conn.SystemService().
+		MacPoolsService().
+		MacPoolService(d.Id()).
+		Get().
+		Send()
+	if err != nil {
+		if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	mp := resp.MustPool()
+
+	d.Set("name", mp.MustName())
+	d.Set("allow_duplicates", mp.MustAllowDuplicates())
+	d.Set("ranges", flattenMacPoolRanges(mp.MustRanges()))
+	if desc, ok := mp.Description(); ok {
+		d.Set("description", desc)
+	}
+
+	return nil
+}
+
+func resourceOvirtMacPoolUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	d.Partial(true)
+	paramBuilder := ovirtsdk4.NewMacPoolBuilder()
+	attributeUpdate := false
+
+	if d.HasChange("name") {
+		paramBuilder.Name(d.Get("name").(string))
+		attributeUpdate = true
+	}
+	if d.HasChange("description") {
+		paramBuilder.Description(d.Get("description").(string))
+		attributeUpdate = true
+	}
+	if d.HasChange("allow_duplicates") {
+		paramBuilder.AllowDuplicates(d.Get("allow_duplicates").(bool))
+		attributeUpdate = true
+	}
+	if d.HasChange("ranges") {
+		paramBuilder.RangesOfAny(expandMacPoolRanges(d.Get("ranges").(*schema.Set))...)
+		attributeUpdate = true
+	}
+
+	if attributeUpdate {
+		_, err := conn.SystemService().
+			MacPoolsService().
+			MacPoolService(d.Id()).
+			Update().
+			Pool(paramBuilder.MustBuild()).
+			Send()
+		if err != nil {
+			log.Printf("[DEBUG] Error updating MacPool (%s): %s", d.Id(), err)
+			return err
+		}
+	}
+
+	d.Partial(false)
+	return resourceOvirtMacPoolRead(d, meta)
+}
+
+func resourceOvirtMacPoolDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	_, err := conn.SystemService().
+		MacPoolsService().
+		MacPoolService(d.Id()).
+		Remove().
+		Send()
+	if err != nil {
+		if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func expandMacPoolRanges(s *schema.Set) []*ovirtsdk4.Range {
+	var ranges []*ovirtsdk4.Range
+	for _, v := range s.List() {
+		r := ovirtsdk4.NewRangeBuilder().
+			From(strings.Split(v.(string), ",")[0]).
+			To(strings.Split(v.(string), ",")[1]).
+			MustBuild()
+		ranges = append(ranges, r)
+	}
+	return ranges
+}
+
+func flattenMacPoolRanges(rs *ovirtsdk4.RangeSlice) []string {
+	var ranges []string
+	for _, r := range rs.Slice() {
+		ranges = append(ranges, fmt.Sprintf("%s,%s", r.MustFrom(), r.MustTo()))
+	}
+	return ranges
+}

--- a/ovirt/resource_ovirt_mac_pool_test.go
+++ b/ovirt/resource_ovirt_mac_pool_test.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2018 Joey Ma <majunjiev@gmail.com>
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func TestAccOvirtMacPool_basic(t *testing.T) {
+	var macpool ovirtsdk4.MacPool
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		Providers:     testAccProviders,
+		IDRefreshName: "ovirt_mac_pool.pool",
+		CheckDestroy:  testAccCheckMacPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMacPoolBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtMacPoolExists("ovirt_mac_pool.pool", &macpool),
+					resource.TestCheckResourceAttr("ovirt_mac_pool.pool", "name", "testAccOvirtMacPoolBasic"),
+					resource.TestCheckResourceAttr("ovirt_mac_pool.pool", "ranges.#", "2"),
+				),
+			},
+			{
+				Config: testAccMacPoolBasicUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtMacPoolExists("ovirt_mac_pool.pool", &macpool),
+					resource.TestCheckResourceAttr("ovirt_mac_pool.pool", "name", "testAccOvirtMacPoolBasicUpdate"),
+					resource.TestCheckResourceAttr("ovirt_mac_pool.pool", "ranges.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMacPoolDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ovirtsdk4.Connection)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ovirt_mac_pool" {
+			continue
+		}
+		getResp, err := conn.SystemService().MacPoolsService().
+			MacPoolService(rs.Primary.ID).
+			Get().
+			Send()
+		if err != nil {
+			if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
+				continue
+			}
+			return err
+		}
+		if _, ok := getResp.Pool(); ok {
+			return fmt.Errorf("MacPool %s still exist", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckOvirtMacPoolExists(n string, v *ovirtsdk4.MacPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No MacPool ID is set")
+		}
+		conn := testAccProvider.Meta().(*ovirtsdk4.Connection)
+		getResp, err := conn.SystemService().MacPoolsService().
+			MacPoolService(rs.Primary.ID).
+			Get().
+			Send()
+		if err != nil {
+			return err
+		}
+		macpool, ok := getResp.Pool()
+		if ok {
+			*v = *macpool
+			return nil
+		}
+		return fmt.Errorf("MacPool %s not exist", rs.Primary.ID)
+	}
+}
+
+func testAccMacPoolBasic() string {
+	return fmt.Sprintf(`
+resource "ovirt_mac_pool" "pool" {
+	name 				= "testAccOvirtMacPoolBasic"
+	description			= "Desc of mac pool"
+	allow_duplicates	= true
+	
+	ranges = [
+		"00:1a:4a:16:01:51,00:1a:4a:16:01:61",
+		"00:1a:4a:16:01:71,00:1a:4a:16:01:81",
+	]
+}`)
+}
+
+func testAccMacPoolBasicUpdate() string {
+	return fmt.Sprintf(`
+resource "ovirt_mac_pool" "pool" {
+	name 				= "testAccOvirtMacPoolBasicUpdate"
+	description			= "Desc of mac pool"
+	allow_duplicates	= true
+	
+	ranges = [
+		"00:1a:4a:16:01:51,00:1a:4a:16:01:61",
+		"00:1a:4a:16:01:91,00:1a:4a:16:01:a1",
+		"00:1a:4a:16:01:b1,00:1a:4a:16:01:c1",
+	]
+}`)
+}


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #104 .

Changes proposed in this pull request:

* Add new resource `ovirt_mac_pool`
* Add acceptance testing for it

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtMacPool_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtMacPool_ -timeout 180m
=== RUN   TestAccOvirtMacPool_basic
--- PASS: TestAccOvirtMacPool_basic (1.71s)
PASS
ok  	github.com/imjoey/terraform-provider-ovirt/ovirt	1.738s
```
