### PR TITLE
New Data Source: ovirt_vms

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ provider "ovirt" {
   * ovirt_networks
   * ovirt_storagedomains
   * ovirt_users
+  * ovirt_vms
   * ovirt_vnic_profiles
 
 Provider Documents

--- a/ovirt/data_source_ovirt_vms.go
+++ b/ovirt/data_source_ovirt_vms.go
@@ -1,0 +1,173 @@
+// Copyright (C) 2018 Joey Ma <majunjiev@gmail.com>
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func dataSourceOvirtVMs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOvirtVMsRead,
+		Schema: map[string]*schema.Schema{
+			"search": dataSourceSearchSchemaWith(
+				"max",
+				"criteria",
+				"case_sensitive",
+			),
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.ValidateRegexp,
+			},
+			// Computed
+			"vms": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"high_availability": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"memory": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cores": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"sockets": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"threads": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOvirtVMsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	vmsReq := conn.SystemService().VmsService().List()
+
+	search, searchOK := d.GetOk("search")
+	nameRegex, nameRegexOK := d.GetOk("name_regex")
+
+	if searchOK {
+		searchMap := search.(map[string]interface{})
+		searchCriteria, searchCriteriaOK := searchMap["criteria"]
+		searchMax, searchMaxOK := searchMap["max"]
+		searchCaseSensitive, searchCaseSensitiveOK := searchMap["case_sensitive"]
+		if !searchCriteriaOK && !searchMaxOK && !searchCaseSensitiveOK {
+			return fmt.Errorf("One of criteria or max or case_sensitive in search must be assigned")
+		}
+
+		if searchCriteriaOK {
+			vmsReq.Search(searchCriteria.(string))
+		}
+		if searchMaxOK {
+			maxInt, err := strconv.ParseInt(searchMax.(string), 10, 64)
+			if err != nil || maxInt < 1 {
+				return fmt.Errorf("search.max must be a positive int")
+			}
+			vmsReq.Max(maxInt)
+		}
+		if searchCaseSensitiveOK {
+			csBool, err := strconv.ParseBool(searchCaseSensitive.(string))
+			if err != nil {
+				return fmt.Errorf("search.case_sensitive must be true or false")
+			}
+			vmsReq.CaseSensitive(csBool)
+		}
+	}
+	vmsResp, err := vmsReq.Send()
+	if err != nil {
+		return err
+	}
+	vms, ok := vmsResp.Vms()
+	if !ok || len(vms.Slice()) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+
+	var filteredVMs []*ovirtsdk4.Vm
+	if nameRegexOK {
+		r := regexp.MustCompile(nameRegex.(string))
+		for _, vm := range vms.Slice() {
+			if r.MatchString(vm.MustName()) {
+				filteredVMs = append(filteredVMs, vm)
+			}
+		}
+	} else {
+		filteredVMs = vms.Slice()[:]
+	}
+
+	if len(filteredVMs) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+
+	return vmsDescriptionAttributes(d, filteredVMs, meta)
+}
+
+func vmsDescriptionAttributes(d *schema.ResourceData, vms []*ovirtsdk4.Vm, meta interface{}) error {
+	var s []map[string]interface{}
+
+	for _, v := range vms {
+		mapping := map[string]interface{}{
+			"id":                v.MustId(),
+			"name":              v.MustName(),
+			"status":            v.MustStatus(),
+			"template_id":       v.MustTemplate().MustId(),
+			"cluster_id":        v.MustCluster().MustId(),
+			"high_availability": v.MustHighAvailability().MustEnabled(),
+			"memory":            v.MustMemory() / int64(math.Pow(2, 20)),
+			"cores":             v.MustCpu().MustTopology().MustCores(),
+			"sockets":           v.MustCpu().MustTopology().MustSockets(),
+			"threads":           v.MustCpu().MustTopology().MustThreads(),
+		}
+		s = append(s, mapping)
+	}
+	d.SetId(resource.UniqueId())
+	return d.Set("vms", s)
+}

--- a/ovirt/data_source_ovirt_vms_test.go
+++ b/ovirt/data_source_ovirt_vms_test.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2018 Joey Ma <majunjiev@gmail.com>
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOvirtVMsDataSource_nameRegexFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtVMsDataSourceNameRegexConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_vms.name_regex_filtered_vm"),
+					resource.TestCheckResourceAttr("data.ovirt_vms.name_regex_filtered_vm", "vms.#", "1"),
+					resource.TestCheckResourceAttr("data.ovirt_vms.name_regex_filtered_vm", "vms.0.name", "HostedEngine"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOvirtVMsDataSource_searchFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtVMsDataSourceSearchConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_vms.search_filtered_vm"),
+					resource.TestCheckResourceAttr("data.ovirt_vms.search_filtered_vm", "vms.#", "1"),
+					resource.TestCheckResourceAttr("data.ovirt_vms.search_filtered_vm", "vms.0.name", "HostedEngine"),
+				),
+			},
+		},
+	})
+}
+
+var testAccCheckOvirtVMsDataSourceNameRegexConfig = `
+data "ovirt_vms" "name_regex_filtered_vm" {
+	name_regex = "\\w*ostedEn*"
+}
+`
+
+var testAccCheckOvirtVMsDataSourceSearchConfig = `
+data "ovirt_vms" "search_filtered_vm" {
+	search = {
+	  criteria       = "name = HostedEngine and status = up"
+	  max            = 2
+	  case_sensitive = false
+	}
+}
+`

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -70,6 +70,7 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_authzs":         dataSourceOvirtAuthzs(),
 			"ovirt_users":          dataSourceOvirtUsers(),
 			"ovirt_mac_pools":      dataSourceOvirtMacPools(),
+			"ovirt_vms":            dataSourceOvirtVMs(),
 		},
 	}
 }


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #116 .

Changes proposed in this pull request:

* Add new data source `ovirt_vms`
* Add acceptance testing for it

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtVMsDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVMsDataSource_ -timeout 180m
=== RUN   TestAccOvirtVMsDataSource_nameRegexFilter
--- PASS: TestAccOvirtVMsDataSource_nameRegexFilter (1.20s)
=== RUN   TestAccOvirtVMsDataSource_searchFilter
--- PASS: TestAccOvirtVMsDataSource_searchFilter (1.12s)
PASS
ok      github.com/imjoey/terraform-provider-ovirt/ovirt        2.354s
```
