### PR TITLE
New Data Source: ovirt_hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ provider "ovirt" {
   * ovirt_clusters
   * ovirt_datacenters
   * ovirt_disks
+  * ovirt_hosts
   * ovirt_mac_pools
   * ovirt_networks
   * ovirt_storagedomains

--- a/ovirt/data_source_ovirt_hosts.go
+++ b/ovirt/data_source_ovirt_hosts.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2019 Joey Ma <majunjiev@gmail.com>
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func dataSourceOvirtHosts() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOvirtHostsRead,
+		Schema: map[string]*schema.Schema{
+			"search": dataSourceSearchSchema(),
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.ValidateRegexp,
+			},
+
+			"hosts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOvirtHostsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	hostsReq := conn.SystemService().HostsService().List()
+
+	search, searchOK := d.GetOk("search")
+	nameRegex, nameRegexOK := d.GetOk("name_regex")
+
+	if searchOK {
+		searchMap := search.(map[string]interface{})
+		searchCriteria, searchCriteriaOK := searchMap["criteria"]
+		searchMax, searchMaxOK := searchMap["max"]
+		searchCaseSensitive, searchCaseSensitiveOK := searchMap["case_sensitive"]
+		if !searchCriteriaOK && !searchMaxOK && !searchCaseSensitiveOK {
+			return fmt.Errorf("One of criteria or max or case_sensitive in search must be assigned")
+		}
+
+		if searchCriteriaOK {
+			hostsReq.Search(searchCriteria.(string))
+		}
+		if searchMaxOK {
+			maxInt, err := strconv.ParseInt(searchMax.(string), 10, 64)
+			if err != nil || maxInt < 1 {
+				return fmt.Errorf("search.max must be a positive int")
+			}
+			hostsReq.Max(maxInt)
+		}
+		if searchCaseSensitiveOK {
+			csBool, err := strconv.ParseBool(searchCaseSensitive.(string))
+			if err != nil {
+				return fmt.Errorf("search.case_sensitive must be true or false")
+			}
+			hostsReq.CaseSensitive(csBool)
+		}
+	}
+	hostsResp, err := hostsReq.Send()
+	if err != nil {
+		return err
+	}
+	hosts, ok := hostsResp.Hosts()
+	if !ok || len(hosts.Slice()) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+
+	var filteredHosts []*ovirtsdk4.Host
+	if nameRegexOK {
+		r := regexp.MustCompile(nameRegex.(string))
+		for _, h := range hosts.Slice() {
+			if r.MatchString(h.MustName()) {
+				filteredHosts = append(filteredHosts, h)
+			}
+		}
+	} else {
+		filteredHosts = hosts.Slice()[:]
+	}
+
+	if len(filteredHosts) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+
+	return hostsDescriptionAttributes(d, filteredHosts, meta)
+}
+
+func hostsDescriptionAttributes(d *schema.ResourceData, hosts []*ovirtsdk4.Host, meta interface{}) error {
+	var s []map[string]interface{}
+	for _, v := range hosts {
+		desc, ok := v.Description()
+		if !ok {
+			desc = ""
+		}
+		mapping := map[string]interface{}{
+			"id":          v.MustId(),
+			"name":        v.MustName(),
+			"cluster_id":  v.MustCluster().MustId(),
+			"address":     v.MustAddress(),
+			"description": desc,
+		}
+		s = append(s, mapping)
+	}
+
+	d.SetId(resource.UniqueId())
+	return d.Set("hosts", s)
+}

--- a/ovirt/data_source_ovirt_hosts_test.go
+++ b/ovirt/data_source_ovirt_hosts_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2019 Joey Ma <majunjiev@gmail.com>
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOvirtHostsDataSource_nameRegexFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtHostsDataSourceNameRegexConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_hosts.name_regex_filtered_host"),
+					resource.TestCheckResourceAttr("data.ovirt_hosts.name_regex_filtered_host", "hosts.#", "2"),
+					resource.TestMatchResourceAttr("data.ovirt_hosts.name_regex_filtered_host", "hosts.0.name", regexp.MustCompile("^host*")),
+					resource.TestMatchResourceAttr("data.ovirt_hosts.name_regex_filtered_host", "hosts.1.name", regexp.MustCompile("^host*")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOvirtHostsDataSource_searchFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtHostsDataSourceSearchConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_hosts.search_filtered_host"),
+					resource.TestCheckResourceAttr("data.ovirt_hosts.search_filtered_host", "hosts.#", "1"),
+					resource.TestCheckResourceAttr("data.ovirt_hosts.search_filtered_host", "hosts.0.name", "host65"),
+				),
+			},
+		},
+	})
+
+}
+
+var testAccCheckOvirtHostsDataSourceNameRegexConfig = `
+data "ovirt_hosts" "name_regex_filtered_host" {
+	name_regex = "^host*"
+  }
+`
+
+var testAccCheckOvirtHostsDataSourceSearchConfig = `
+data "ovirt_hosts" "search_filtered_host" {
+	search = {
+	  criteria       = "name = host65"
+	  max            = 1
+	  case_sensitive = false
+	}
+}
+`

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -72,6 +72,7 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_users":          dataSourceOvirtUsers(),
 			"ovirt_mac_pools":      dataSourceOvirtMacPools(),
 			"ovirt_vms":            dataSourceOvirtVMs(),
+			"ovirt_hosts":          dataSourceOvirtHosts(),
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>


Changes proposed in this pull request:

* Add new data source `ovirt_hosts` support for querying existing hosts
* Add acceptance testing for `ovirt_hosts`

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtHostsDataSource_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtHostsDataSource_* -timeout 180m
=== RUN   TestAccOvirtHostsDataSource_nameRegexFilter
--- PASS: TestAccOvirtHostsDataSource_nameRegexFilter (0.78s)
=== RUN   TestAccOvirtHostsDataSource_searchFilter
--- PASS: TestAccOvirtHostsDataSource_searchFilter (0.68s)
PASS
ok      github.com/imjoey/terraform-provider-ovirt/ovirt        1.486s
```
