### PR TITLE
Fix panics due to no VM original_template attribute

### DIFF
--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -501,9 +501,12 @@ func resourceOvirtVMRead(d *schema.ResourceData, meta interface{}) error {
 	// If the virtual machine is cloned from a template or another virtual machine,
 	// the template links to the Blank template, and the original_template is used to track history.
 	// Otherwise the template and original_template are the same.
-	templateCloned := vm.MustTemplate().MustId() != vm.MustOriginalTemplate().MustId() && vm.MustTemplate().MustId() == BlankTemplateID
+	originalTemplate, originalTemplateOk := vm.OriginalTemplate()
+	templateCloned := originalTemplateOk &&
+		vm.MustTemplate().MustId() != originalTemplate.MustId() &&
+		vm.MustTemplate().MustId() == BlankTemplateID
 	if templateCloned {
-		d.Set("template_id", vm.MustOriginalTemplate().MustId())
+		d.Set("template_id", originalTemplate.MustId())
 	} else {
 		d.Set("template_id", vm.MustTemplate().MustId())
 	}


### PR DESCRIPTION
The VM (HostedEngine) may has no `original_template attribute`, which
may lead to panics when reading a VM resource. See #139 for bug details.
This pr improved the codes logic to fix the issue.

Signed-off-by: imjoey <majunjiev@gmail.com>

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #139 

Changes proposed in this pull request:

* Use `Originaltemplate()` to retrieve the attribute instead of its `MustOriginaltemplate()` counterpart

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtVM_templateClone'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVM_templateClone -timeout 180m
=== RUN   TestAccOvirtVM_templateClone
--- PASS: TestAccOvirtVM_templateClone (101.93s)
PASS
ok  	github.com/imjoey/terraform-provider-ovirt/ovirt	101.960s
```
